### PR TITLE
[A2] Tray-first runtime, startup toggle, and explicit exit semantics

### DIFF
--- a/apps/desktop/src/lifecycle.test.ts
+++ b/apps/desktop/src/lifecycle.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createExitHandler,
+  DEFAULT_RUNTIME_SETTINGS,
+  mergeRuntimeSettings,
+  shouldMinimizeToTrayOnClose
+} from "./lifecycle";
+
+describe("runtime lifecycle helpers", () => {
+  it("keeps app running in tray when close-to-tray is enabled", () => {
+    expect(shouldMinimizeToTrayOnClose(DEFAULT_RUNTIME_SETTINGS, false)).toBe(true);
+  });
+
+  it("persists startup preference through merged settings updates", () => {
+    const updated = mergeRuntimeSettings(DEFAULT_RUNTIME_SETTINGS, {
+      startWithWindows: false
+    });
+    expect(updated.startWithWindows).toBe(false);
+    expect(updated.minimizeToTray).toBe(true);
+  });
+
+  it("stops scheduler and quits app when explicit exit is requested", () => {
+    const stopScheduler = vi.fn();
+    const quitApp = vi.fn();
+
+    const exit = createExitHandler(stopScheduler, quitApp);
+    exit();
+
+    expect(stopScheduler).toHaveBeenCalledTimes(1);
+    expect(quitApp).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/apps/desktop/src/lifecycle.ts
+++ b/apps/desktop/src/lifecycle.ts
@@ -1,0 +1,40 @@
+export interface RuntimeSettings {
+  startWithWindows: boolean;
+  minimizeToTray: boolean;
+}
+
+export const DEFAULT_RUNTIME_SETTINGS: RuntimeSettings = {
+  startWithWindows: true,
+  minimizeToTray: true
+};
+
+export function mergeRuntimeSettings(
+  current: RuntimeSettings,
+  update: Partial<RuntimeSettings>
+): RuntimeSettings {
+  return {
+    startWithWindows:
+      typeof update.startWithWindows === "boolean"
+        ? update.startWithWindows
+        : current.startWithWindows,
+    minimizeToTray:
+      typeof update.minimizeToTray === "boolean"
+        ? update.minimizeToTray
+        : current.minimizeToTray
+  };
+}
+
+export function shouldMinimizeToTrayOnClose(
+  settings: RuntimeSettings,
+  isQuitting: boolean
+): boolean {
+  return settings.minimizeToTray && !isQuitting;
+}
+
+export function createExitHandler(stopScheduler: () => void, quitApp: () => void): () => void {
+  return () => {
+    stopScheduler();
+    quitApp();
+  };
+}
+

--- a/apps/desktop/src/settings-store.test.ts
+++ b/apps/desktop/src/settings-store.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readRuntimeSettings, writeRuntimeSettings } from "./settings-store";
+
+const tempRoots: string[] = [];
+
+function makeTempSettingsPath(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-settings-"));
+  tempRoots.push(root);
+  return path.join(root, "runtime-settings.json");
+}
+
+describe("runtime settings persistence", () => {
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("reads default settings when no settings file exists", () => {
+    const settingsPath = makeTempSettingsPath();
+    const settings = readRuntimeSettings(settingsPath);
+
+    expect(settings.startWithWindows).toBe(true);
+    expect(settings.minimizeToTray).toBe(true);
+  });
+
+  it("writes and reads updated startup settings", () => {
+    const settingsPath = makeTempSettingsPath();
+    writeRuntimeSettings(settingsPath, {
+      startWithWindows: false,
+      minimizeToTray: true
+    });
+
+    const settings = readRuntimeSettings(settingsPath);
+    expect(settings.startWithWindows).toBe(false);
+    expect(settings.minimizeToTray).toBe(true);
+  });
+});
+

--- a/apps/desktop/src/settings-store.ts
+++ b/apps/desktop/src/settings-store.ts
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { DEFAULT_RUNTIME_SETTINGS, mergeRuntimeSettings, type RuntimeSettings } from "./lifecycle";
+
+export function readRuntimeSettings(filePath: string): RuntimeSettings {
+  if (!fs.existsSync(filePath)) {
+    return DEFAULT_RUNTIME_SETTINGS;
+  }
+
+  const raw = fs.readFileSync(filePath, "utf8");
+  const parsed = JSON.parse(raw) as Partial<RuntimeSettings>;
+  return mergeRuntimeSettings(DEFAULT_RUNTIME_SETTINGS, parsed);
+}
+
+export function writeRuntimeSettings(filePath: string, settings: RuntimeSettings): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(settings, null, 2), "utf8");
+}
+

--- a/apps/renderer/src/App.css
+++ b/apps/renderer/src/App.css
@@ -2,6 +2,8 @@
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   padding: 2rem;
   color: #222;
+  display: grid;
+  gap: 1.5rem;
 }
 
 h1 {
@@ -10,5 +12,27 @@ h1 {
 
 p {
   margin: 0;
+}
+
+.settings-panel {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 28rem;
+}
+
+.settings-panel label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.settings-panel button {
+  width: fit-content;
+  padding: 0.5rem 0.75rem;
+}
+
+.status {
+  font-size: 0.9rem;
+  color: #555;
 }
 

--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -1,10 +1,93 @@
+import { useEffect, useState } from "react";
+
+type RuntimeSettings = {
+  startWithWindows: boolean;
+  minimizeToTray: boolean;
+};
+
+const defaultSettings: RuntimeSettings = {
+  startWithWindows: true,
+  minimizeToTray: true
+};
+
+async function getSettings(): Promise<RuntimeSettings> {
+  if (!window.budgetit) {
+    return defaultSettings;
+  }
+
+  return (await window.budgetit.invoke("settings.get")) as RuntimeSettings;
+}
+
+async function saveSettings(settings: RuntimeSettings): Promise<RuntimeSettings> {
+  if (!window.budgetit) {
+    return settings;
+  }
+
+  return (await window.budgetit.invoke("settings.update", settings)) as RuntimeSettings;
+}
+
 export function App() {
+  const [settings, setSettings] = useState<RuntimeSettings>(defaultSettings);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState("Loaded defaults");
+
+  useEffect(() => {
+    void (async () => {
+      const next = await getSettings();
+      setSettings(next);
+      setStatus("Runtime settings loaded");
+    })();
+  }, []);
+
+  async function onSave(): Promise<void> {
+    setSaving(true);
+    const next = await saveSettings(settings);
+    setSettings(next);
+    setSaving(false);
+    setStatus("Runtime settings saved");
+  }
+
   return (
     <main className="app-shell">
       <header>
         <h1>BudgetIT</h1>
-        <p>Electron + React + TypeScript monorepo scaffold is ready.</p>
+        <p>Tray and startup defaults are configurable.</p>
       </header>
+
+      <section className="settings-panel">
+        <label>
+          <input
+            type="checkbox"
+            checked={settings.startWithWindows}
+            onChange={(event) => {
+              setSettings((current) => ({
+                ...current,
+                startWithWindows: event.target.checked
+              }));
+            }}
+          />
+          Start with Windows
+        </label>
+
+        <label>
+          <input
+            type="checkbox"
+            checked={settings.minimizeToTray}
+            onChange={(event) => {
+              setSettings((current) => ({
+                ...current,
+                minimizeToTray: event.target.checked
+              }));
+            }}
+          />
+          Minimize to tray on close
+        </label>
+
+        <button type="button" disabled={saving} onClick={() => void onSave()}>
+          {saving ? "Saving..." : "Save runtime settings"}
+        </button>
+        <p className="status">{status}</p>
+      </section>
     </main>
   );
 }

--- a/apps/renderer/src/budgetit.d.ts
+++ b/apps/renderer/src/budgetit.d.ts
@@ -1,0 +1,10 @@
+declare global {
+  interface Window {
+    budgetit?: {
+      invoke: (channel: string, payload?: unknown) => Promise<unknown>;
+    };
+  }
+}
+
+export {};
+


### PR DESCRIPTION
## Summary
- added runtime lifecycle helpers for close-to-tray and explicit exit semantics
- implemented persisted runtime settings for startWithWindows and minimizeToTray
- wired Electron main process tray menu (Show, Snooze alerts, Exit) and startup behavior
- added renderer settings UI for startup/tray toggles using IPC settings.get and settings.update
- added tests covering tray-close behavior, settings persistence, and clean exit path

## Verification
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Closes #9