### PR TITLE
[A6] Drizzle schema, migrations, validation, and audit logging baseline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3452,6 +3452,126 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/drizzle-orm": {
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.43.1.tgz",
+      "integrity": "sha512-dUcDaZtE/zN4RV/xqGrVSMpnEczxd5cIaoDeor7Zst9wOe/HzC/7eAaulywWGYXdDEc9oBPMjayVEDg0ziTLJA==",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -7609,14 +7729,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/core": {
       "name": "@budgetit/core",
       "version": "0.1.0"
     },
     "packages/db": {
+      "name": "@budgetit/db",
       "version": "0.1.0",
       "dependencies": {
-        "better-sqlite3-multiple-ciphers": "^12.4.1"
+        "better-sqlite3-multiple-ciphers": "^12.4.1",
+        "drizzle-orm": "^0.43.1",
+        "zod": "^3.24.2"
       }
     }
   }

--- a/packages/db/migrations/001_initial.sql
+++ b/packages/db/migrations/001_initial.sql
@@ -1,0 +1,201 @@
+CREATE TABLE IF NOT EXISTS meta (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  database_uuid TEXT NOT NULL,
+  schema_version INTEGER NOT NULL,
+  last_mutation_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT OR IGNORE INTO meta (id, database_uuid, schema_version, last_mutation_at)
+VALUES (1, 'bootstrap', 1, CURRENT_TIMESTAMP);
+
+CREATE TABLE IF NOT EXISTS vendor (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  website TEXT,
+  notes TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS service (
+  id TEXT PRIMARY KEY,
+  vendor_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL,
+  owner_team TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS contract (
+  id TEXT PRIMARY KEY,
+  service_id TEXT NOT NULL,
+  contract_number TEXT,
+  start_date TEXT,
+  end_date TEXT,
+  renewal_type TEXT,
+  renewal_date TEXT,
+  notice_period_days INTEGER,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS expense_line (
+  id TEXT PRIMARY KEY,
+  scenario_id TEXT NOT NULL,
+  service_id TEXT NOT NULL,
+  contract_id TEXT,
+  name TEXT NOT NULL,
+  expense_type TEXT NOT NULL,
+  status TEXT NOT NULL,
+  amount_minor INTEGER NOT NULL,
+  currency TEXT NOT NULL,
+  start_date TEXT,
+  end_date TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  deleted_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS recurrence_rule (
+  id TEXT PRIMARY KEY,
+  expense_line_id TEXT NOT NULL,
+  frequency TEXT NOT NULL,
+  interval INTEGER NOT NULL,
+  day_of_month INTEGER,
+  month_of_year INTEGER,
+  anchor_date TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS occurrence (
+  id TEXT PRIMARY KEY,
+  scenario_id TEXT NOT NULL,
+  expense_line_id TEXT NOT NULL,
+  occurrence_date TEXT NOT NULL,
+  amount_minor INTEGER NOT NULL,
+  currency TEXT NOT NULL,
+  state TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS spend_transaction (
+  id TEXT PRIMARY KEY,
+  scenario_id TEXT NOT NULL,
+  service_id TEXT NOT NULL,
+  contract_id TEXT,
+  transaction_date TEXT NOT NULL,
+  amount_minor INTEGER NOT NULL,
+  currency TEXT NOT NULL,
+  description TEXT,
+  matched_occurrence_id TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS dimension (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  mode TEXT NOT NULL,
+  required INTEGER NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS tag (
+  id TEXT PRIMARY KEY,
+  dimension_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  parent_tag_id TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  archived_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS tag_assignment (
+  id TEXT PRIMARY KEY,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  dimension_id TEXT NOT NULL,
+  tag_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS service_plan (
+  id TEXT PRIMARY KEY,
+  scenario_id TEXT NOT NULL,
+  service_id TEXT NOT NULL,
+  planned_action TEXT NOT NULL,
+  decision_status TEXT NOT NULL,
+  reason_code TEXT,
+  must_replace_by TEXT,
+  replacement_required INTEGER NOT NULL,
+  replacement_selected_service_id TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS replacement_candidate (
+  id TEXT PRIMARY KEY,
+  service_plan_id TEXT NOT NULL,
+  candidate_service_id TEXT,
+  candidate_name TEXT,
+  score INTEGER,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS alert_rule (
+  id TEXT PRIMARY KEY,
+  scenario_id TEXT NOT NULL,
+  rule_type TEXT NOT NULL,
+  params_json TEXT NOT NULL,
+  enabled INTEGER NOT NULL,
+  channels TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS alert_event (
+  id TEXT PRIMARY KEY,
+  scenario_id TEXT NOT NULL,
+  alert_rule_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  fire_at TEXT NOT NULL,
+  fired_at TEXT,
+  status TEXT NOT NULL,
+  dedupe_key TEXT NOT NULL,
+  message TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  id TEXT PRIMARY KEY,
+  actor TEXT NOT NULL,
+  action TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  before_json TEXT,
+  after_json TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS attachment (
+  id TEXT PRIMARY KEY,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  file_name TEXT NOT NULL,
+  file_path TEXT NOT NULL,
+  content_sha256 TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/packages/db/migrations/002_audit_indexes.sql
+++ b/packages/db/migrations/002_audit_indexes.sql
@@ -1,0 +1,8 @@
+CREATE INDEX IF NOT EXISTS idx_occurrence_date ON occurrence (scenario_id, occurrence_date);
+CREATE INDEX IF NOT EXISTS idx_alert_event_status ON alert_event (status, fire_at);
+CREATE INDEX IF NOT EXISTS idx_audit_entity ON audit_log (entity_type, entity_id, created_at);
+
+UPDATE meta
+SET schema_version = 2,
+    updated_at = CURRENT_TIMESTAMP;
+

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,11 +10,13 @@
   "scripts": {
     "lint": "eslint \"src/**/*.ts\"",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "vitest run src/encrypted-db.test.ts",
+    "test": "vitest run",
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "better-sqlite3-multiple-ciphers": "^12.4.1"
+    "better-sqlite3-multiple-ciphers": "^12.4.1",
+    "drizzle-orm": "^0.43.1",
+    "zod": "^3.24.2"
   }
 }
 

--- a/packages/db/src/audit-service.test.ts
+++ b/packages/db/src/audit-service.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { updateExpenseLineAmountWithAudit } from "./audit-service";
+import { bootstrapEncryptedDatabase } from "./encrypted-db";
+import { runMigrations } from "./migrations";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-audit-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("audit service", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes before/after audit entries for critical amount updates", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+
+      boot.db.prepare(
+        `
+          INSERT INTO expense_line (
+            id,
+            scenario_id,
+            service_id,
+            contract_id,
+            name,
+            expense_type,
+            status,
+            amount_minor,
+            currency,
+            start_date,
+            end_date,
+            created_at,
+            updated_at,
+            deleted_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL)
+        `
+      ).run(
+        "exp-1",
+        "baseline",
+        "svc-1",
+        null,
+        "Licenses",
+        "recurring",
+        "planned",
+        10000,
+        "USD",
+        "2026-01-01",
+        null
+      );
+
+      updateExpenseLineAmountWithAudit(boot.db, {
+        expenseLineId: "exp-1",
+        newAmountMinor: 15000,
+        actor: "local-user"
+      });
+
+      const auditRow = boot.db
+        .prepare(
+          `
+            SELECT before_json, after_json
+            FROM audit_log
+            WHERE entity_type = 'expense_line'
+              AND entity_id = 'exp-1'
+          `
+        )
+        .get() as { before_json: string; after_json: string };
+
+      const before = JSON.parse(auditRow.before_json) as { amount_minor: number };
+      const after = JSON.parse(auditRow.after_json) as { amount_minor: number };
+      expect(before.amount_minor).toBe(10000);
+      expect(after.amount_minor).toBe(15000);
+
+      const mutatedMeta = boot.db
+        .prepare("SELECT last_mutation_at FROM meta WHERE id = 1")
+        .get() as { last_mutation_at: string };
+      expect(mutatedMeta.last_mutation_at.length).toBeGreaterThan(0);
+    } finally {
+      boot.db.close();
+    }
+  });
+});

--- a/packages/db/src/audit-service.ts
+++ b/packages/db/src/audit-service.ts
@@ -1,0 +1,81 @@
+import crypto from "node:crypto";
+
+import type Database from "better-sqlite3-multiple-ciphers";
+import { z } from "zod";
+
+const updateExpenseAmountSchema = z.object({
+  expenseLineId: z.string().min(1),
+  newAmountMinor: z.number().int().nonnegative(),
+  actor: z.string().min(1)
+});
+
+export type UpdateExpenseAmountInput = z.infer<typeof updateExpenseAmountSchema>;
+
+export function updateExpenseLineAmountWithAudit(
+  db: Database.Database,
+  input: UpdateExpenseAmountInput
+): void {
+  const parsed = updateExpenseAmountSchema.parse(input);
+
+  const before = db
+    .prepare("SELECT amount_minor, currency, updated_at FROM expense_line WHERE id = ?")
+    .get(parsed.expenseLineId) as
+    | { amount_minor: number; currency: string; updated_at: string }
+    | undefined;
+
+  if (!before) {
+    throw new Error(`Expense line not found: ${parsed.expenseLineId}`);
+  }
+
+  const now = new Date().toISOString();
+  const after = {
+    amount_minor: parsed.newAmountMinor,
+    currency: before.currency,
+    updated_at: now
+  };
+
+  const write = db.transaction(() => {
+    db.prepare(
+      `
+        UPDATE expense_line
+        SET amount_minor = ?, updated_at = ?
+        WHERE id = ?
+      `
+    ).run(parsed.newAmountMinor, now, parsed.expenseLineId);
+
+    db.prepare(
+      `
+        INSERT INTO audit_log (
+          id,
+          actor,
+          action,
+          entity_type,
+          entity_id,
+          before_json,
+          after_json,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `
+    ).run(
+      crypto.randomUUID(),
+      parsed.actor,
+      "expense_line.update_amount",
+      "expense_line",
+      parsed.expenseLineId,
+      JSON.stringify(before),
+      JSON.stringify(after),
+      now
+    );
+
+    db.prepare(
+      `
+        UPDATE meta
+        SET last_mutation_at = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE id = 1
+      `
+    ).run(now);
+  });
+
+  write();
+}
+

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -6,3 +6,7 @@ export {
   type BootstrapEncryptedDatabaseResult
 } from "./encrypted-db";
 
+export { runMigrations, resolveDefaultMigrationsDir } from "./migrations";
+export { updateExpenseLineAmountWithAudit, type UpdateExpenseAmountInput } from "./audit-service";
+export * as schema from "./schema";
+

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { bootstrapEncryptedDatabase } from "./encrypted-db";
+import { runMigrations } from "./migrations";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-migrate-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function readMigrationSql(fileName: string): string {
+  const migrationsDir = path.resolve(__dirname, "../migrations");
+  return fs.readFileSync(path.join(migrationsDir, fileName), "utf8");
+}
+
+describe("migration runner", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("applies all migrations for a fresh encrypted database", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      const applied = runMigrations(boot.db);
+      expect(applied).toEqual(["001_initial.sql", "002_audit_indexes.sql"]);
+
+      const metaRow = boot.db
+        .prepare("SELECT schema_version, last_mutation_at FROM meta WHERE id = 1")
+        .get() as { schema_version: number; last_mutation_at: string };
+      expect(metaRow.schema_version).toBe(2);
+      expect(metaRow.last_mutation_at.length).toBeGreaterThan(0);
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("upgrades a database from a prior migration fixture", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      const initialSql = readMigrationSql("001_initial.sql");
+      boot.db.exec(initialSql);
+      boot.db
+        .prepare(
+          `
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              file_name TEXT NOT NULL UNIQUE,
+              applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+          `
+        )
+        .run();
+      boot.db
+        .prepare("INSERT INTO schema_migrations (file_name) VALUES (?)")
+        .run("001_initial.sql");
+
+      const applied = runMigrations(boot.db);
+      expect(applied).toEqual(["002_audit_indexes.sql"]);
+
+      const indexRow = boot.db
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_audit_entity'")
+        .get() as { name: string } | undefined;
+      expect(indexRow?.name).toBe("idx_audit_entity");
+    } finally {
+      boot.db.close();
+    }
+  });
+});

--- a/packages/db/src/migrations.ts
+++ b/packages/db/src/migrations.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type Database from "better-sqlite3-multiple-ciphers";
+
+const MIGRATIONS_TABLE = "schema_migrations";
+
+export function resolveDefaultMigrationsDir(): string {
+  return path.resolve(__dirname, "../migrations");
+}
+
+function ensureMigrationsTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ${MIGRATIONS_TABLE} (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      file_name TEXT NOT NULL UNIQUE,
+      applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+}
+
+function listMigrationFiles(migrationsDir: string): string[] {
+  return fs
+    .readdirSync(migrationsDir)
+    .filter((fileName) => fileName.endsWith(".sql"))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function getAppliedMigrationSet(db: Database.Database): Set<string> {
+  const rows = db
+    .prepare(`SELECT file_name FROM ${MIGRATIONS_TABLE} ORDER BY file_name`)
+    .all() as Array<{ file_name: string }>;
+  return new Set(rows.map((row) => row.file_name));
+}
+
+export function runMigrations(
+  db: Database.Database,
+  migrationsDir: string = resolveDefaultMigrationsDir()
+): string[] {
+  ensureMigrationsTable(db);
+  const applied = getAppliedMigrationSet(db);
+  const migrationFiles = listMigrationFiles(migrationsDir);
+  const newlyApplied: string[] = [];
+
+  for (const fileName of migrationFiles) {
+    if (applied.has(fileName)) {
+      continue;
+    }
+
+    const sql = fs.readFileSync(path.join(migrationsDir, fileName), "utf8");
+    const apply = db.transaction(() => {
+      db.exec(sql);
+      db.prepare(`INSERT INTO ${MIGRATIONS_TABLE} (file_name) VALUES (?)`).run(fileName);
+    });
+
+    apply();
+    newlyApplied.push(fileName);
+  }
+
+  return newlyApplied;
+}
+

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,0 +1,200 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const meta = sqliteTable("meta", {
+  id: integer("id").primaryKey(),
+  databaseUuid: text("database_uuid").notNull(),
+  schemaVersion: integer("schema_version").notNull(),
+  lastMutationAt: text("last_mutation_at").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const vendor = sqliteTable("vendor", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  website: text("website"),
+  notes: text("notes"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  deletedAt: text("deleted_at")
+});
+
+export const service = sqliteTable("service", {
+  id: text("id").primaryKey(),
+  vendorId: text("vendor_id").notNull(),
+  name: text("name").notNull(),
+  status: text("status").notNull(),
+  ownerTeam: text("owner_team"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  deletedAt: text("deleted_at")
+});
+
+export const contract = sqliteTable("contract", {
+  id: text("id").primaryKey(),
+  serviceId: text("service_id").notNull(),
+  contractNumber: text("contract_number"),
+  startDate: text("start_date"),
+  endDate: text("end_date"),
+  renewalType: text("renewal_type"),
+  renewalDate: text("renewal_date"),
+  noticePeriodDays: integer("notice_period_days"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  deletedAt: text("deleted_at")
+});
+
+export const expenseLine = sqliteTable("expense_line", {
+  id: text("id").primaryKey(),
+  scenarioId: text("scenario_id").notNull(),
+  serviceId: text("service_id").notNull(),
+  contractId: text("contract_id"),
+  name: text("name").notNull(),
+  expenseType: text("expense_type").notNull(),
+  status: text("status").notNull(),
+  amountMinor: integer("amount_minor").notNull(),
+  currency: text("currency").notNull(),
+  startDate: text("start_date"),
+  endDate: text("end_date"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  deletedAt: text("deleted_at")
+});
+
+export const recurrenceRule = sqliteTable("recurrence_rule", {
+  id: text("id").primaryKey(),
+  expenseLineId: text("expense_line_id").notNull(),
+  frequency: text("frequency").notNull(),
+  interval: integer("interval").notNull(),
+  dayOfMonth: integer("day_of_month"),
+  monthOfYear: integer("month_of_year"),
+  anchorDate: text("anchor_date"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const occurrence = sqliteTable("occurrence", {
+  id: text("id").primaryKey(),
+  scenarioId: text("scenario_id").notNull(),
+  expenseLineId: text("expense_line_id").notNull(),
+  occurrenceDate: text("occurrence_date").notNull(),
+  amountMinor: integer("amount_minor").notNull(),
+  currency: text("currency").notNull(),
+  state: text("state").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const spendTransaction = sqliteTable("spend_transaction", {
+  id: text("id").primaryKey(),
+  scenarioId: text("scenario_id").notNull(),
+  serviceId: text("service_id").notNull(),
+  contractId: text("contract_id"),
+  transactionDate: text("transaction_date").notNull(),
+  amountMinor: integer("amount_minor").notNull(),
+  currency: text("currency").notNull(),
+  description: text("description"),
+  matchedOccurrenceId: text("matched_occurrence_id"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const dimension = sqliteTable("dimension", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  mode: text("mode").notNull(),
+  required: integer("required").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const tag = sqliteTable("tag", {
+  id: text("id").primaryKey(),
+  dimensionId: text("dimension_id").notNull(),
+  name: text("name").notNull(),
+  parentTagId: text("parent_tag_id"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull(),
+  archivedAt: text("archived_at")
+});
+
+export const tagAssignment = sqliteTable("tag_assignment", {
+  id: text("id").primaryKey(),
+  entityType: text("entity_type").notNull(),
+  entityId: text("entity_id").notNull(),
+  dimensionId: text("dimension_id").notNull(),
+  tagId: text("tag_id").notNull(),
+  createdAt: text("created_at").notNull()
+});
+
+export const servicePlan = sqliteTable("service_plan", {
+  id: text("id").primaryKey(),
+  scenarioId: text("scenario_id").notNull(),
+  serviceId: text("service_id").notNull(),
+  plannedAction: text("planned_action").notNull(),
+  decisionStatus: text("decision_status").notNull(),
+  reasonCode: text("reason_code"),
+  mustReplaceBy: text("must_replace_by"),
+  replacementRequired: integer("replacement_required").notNull(),
+  replacementSelectedServiceId: text("replacement_selected_service_id"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const replacementCandidate = sqliteTable("replacement_candidate", {
+  id: text("id").primaryKey(),
+  servicePlanId: text("service_plan_id").notNull(),
+  candidateServiceId: text("candidate_service_id"),
+  candidateName: text("candidate_name"),
+  score: integer("score"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const alertRule = sqliteTable("alert_rule", {
+  id: text("id").primaryKey(),
+  scenarioId: text("scenario_id").notNull(),
+  ruleType: text("rule_type").notNull(),
+  paramsJson: text("params_json").notNull(),
+  enabled: integer("enabled").notNull(),
+  channels: text("channels").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const alertEvent = sqliteTable("alert_event", {
+  id: text("id").primaryKey(),
+  scenarioId: text("scenario_id").notNull(),
+  alertRuleId: text("alert_rule_id").notNull(),
+  entityType: text("entity_type").notNull(),
+  entityId: text("entity_id").notNull(),
+  fireAt: text("fire_at").notNull(),
+  firedAt: text("fired_at"),
+  status: text("status").notNull(),
+  dedupeKey: text("dedupe_key").notNull(),
+  message: text("message").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
+export const auditLog = sqliteTable("audit_log", {
+  id: text("id").primaryKey(),
+  actor: text("actor").notNull(),
+  action: text("action").notNull(),
+  entityType: text("entity_type").notNull(),
+  entityId: text("entity_id").notNull(),
+  beforeJson: text("before_json"),
+  afterJson: text("after_json"),
+  createdAt: text("created_at").notNull()
+});
+
+export const attachment = sqliteTable("attachment", {
+  id: text("id").primaryKey(),
+  entityType: text("entity_type").notNull(),
+  entityId: text("entity_id").notNull(),
+  fileName: text("file_name").notNull(),
+  filePath: text("file_path").notNull(),
+  contentSha256: text("content_sha256"),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});


### PR DESCRIPTION
## Summary
- added Drizzle schema definitions for core domain tables (including meta.last_mutation_at)
- added SQL migrations and migration runner with applied-migration tracking
- added validated expense amount update service with before/after audit log entries
- added migration tests for fresh bootstrap and prior-version upgrade fixture
- added audit test asserting before/after snapshots and mutation timestamp updates

## Verification
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Closes #13