### PR TITLE
[B4] Scenario clone, snapshot lock, and approval markers

### DIFF
--- a/apps/renderer/src/App.tsx
+++ b/apps/renderer/src/App.tsx
@@ -46,6 +46,9 @@ export function App() {
   const [assignments, setAssignments] = useState<
     Array<{ entityType: "expense_line"; entityId: string; dimensionId: string; tagId: string }>
   >([]);
+  const [scenarios, setScenarios] = useState<
+    Array<{ id: string; name: string; approval: "draft" | "reviewed" | "approved"; locked: boolean; parentId?: string }>
+  >([{ id: "baseline", name: "Baseline", approval: "approved", locked: false }]);
   const [vendorName, setVendorName] = useState("");
   const [serviceName, setServiceName] = useState("");
   const [contractNumber, setContractNumber] = useState("");
@@ -57,6 +60,7 @@ export function App() {
   const [dimensionRequired, setDimensionRequired] = useState(false);
   const [tagName, setTagName] = useState("");
   const [selectedFilterTagId, setSelectedFilterTagId] = useState("");
+  const [scenarioName, setScenarioName] = useState("");
 
   useEffect(() => {
     void (async () => {
@@ -161,6 +165,70 @@ export function App() {
                 </button>
                 <button type="button" onClick={() => setVendors((current) => current.filter((entry) => entry.id !== vendor.id))}>
                   Delete
+                </button>
+              </li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="crud-card">
+          <h2>Scenarios</h2>
+          <div className="crud-form">
+            <input
+              value={scenarioName}
+              onChange={(event) => setScenarioName(event.target.value)}
+              placeholder="Scenario name"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                if (!scenarioName.trim()) return;
+                setScenarios((current) => [
+                  ...current,
+                  {
+                    id: nextId("scenario"),
+                    name: scenarioName.trim(),
+                    approval: "draft",
+                    locked: false,
+                    parentId: current[0]?.id
+                  }
+                ]);
+                setScenarioName("");
+              }}
+            >
+              Clone from first scenario
+            </button>
+          </div>
+          <ul>
+            {scenarios.map((scenario) => (
+              <li key={scenario.id}>
+                <span>
+                  {scenario.name} [{scenario.approval}] {scenario.locked ? "(locked)" : ""}
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setScenarios((current) =>
+                      current.map((entry) => {
+                        if (entry.id !== scenario.id || entry.locked) return entry;
+                        if (entry.approval === "draft") return { ...entry, approval: "reviewed" };
+                        if (entry.approval === "reviewed") return { ...entry, approval: "approved" };
+                        return entry;
+                      })
+                    )
+                  }
+                >
+                  Advance approval
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setScenarios((current) =>
+                      current.map((entry) => (entry.id === scenario.id ? { ...entry, locked: true } : entry))
+                    )
+                  }
+                >
+                  Lock
                 </button>
               </li>
             ))}

--- a/packages/db/migrations/005_scenarios.sql
+++ b/packages/db/migrations/005_scenarios.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS scenario (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  parent_scenario_id TEXT,
+  approval_status TEXT NOT NULL DEFAULT 'draft',
+  is_locked INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT OR IGNORE INTO scenario (id, name, parent_scenario_id, approval_status, is_locked)
+VALUES ('baseline', 'Baseline', NULL, 'approved', 0);
+
+UPDATE meta
+SET schema_version = 5,
+    updated_at = CURRENT_TIMESTAMP;
+

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -36,13 +36,14 @@ describe("migration runner", () => {
         "001_initial.sql",
         "002_audit_indexes.sql",
         "003_tag_assignment_indexes.sql",
-        "004_forecast_state.sql"
+        "004_forecast_state.sql",
+        "005_scenarios.sql"
       ]);
 
       const metaRow = boot.db
         .prepare("SELECT schema_version, last_mutation_at, forecast_stale FROM meta WHERE id = 1")
         .get() as { schema_version: number; last_mutation_at: string; forecast_stale: number };
-      expect(metaRow.schema_version).toBe(4);
+      expect(metaRow.schema_version).toBe(5);
       expect(metaRow.forecast_stale).toBe(1);
       expect(metaRow.last_mutation_at.length).toBeGreaterThan(0);
     } finally {
@@ -75,7 +76,8 @@ describe("migration runner", () => {
       expect(applied).toEqual([
         "002_audit_indexes.sql",
         "003_tag_assignment_indexes.sql",
-        "004_forecast_state.sql"
+        "004_forecast_state.sql",
+        "005_scenarios.sql"
       ]);
 
       const indexRow = boot.db

--- a/packages/db/src/scenario.test.ts
+++ b/packages/db/src/scenario.test.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { bootstrapEncryptedDatabase } from "./encrypted-db";
+import { runMigrations } from "./migrations";
+import { BudgetCrudRepository } from "./repositories";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-scenario-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("scenario workflows", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("clones scenario data with expense/recurrence integrity", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const vendorId = repo.createVendor({ name: "Vendor" });
+      const serviceId = repo.createService({ vendorId, name: "Service", status: "active" });
+      const sourceScenarioId = repo.createScenario({ name: "Source", approvalStatus: "draft" });
+
+      repo.createExpenseLineWithOptionalRecurrence(
+        {
+          scenarioId: sourceScenarioId,
+          serviceId,
+          name: "Clonable Expense",
+          expenseType: "recurring",
+          status: "planned",
+          amountMinor: 4200,
+          currency: "USD",
+          startDate: "2026-01-01"
+        },
+        {
+          expenseLineId: "ignored",
+          frequency: "monthly",
+          interval: 1,
+          dayOfMonth: 1,
+          anchorDate: "2026-01-01"
+        }
+      );
+
+      const clonedScenarioId = repo.cloneScenario(sourceScenarioId, "Clone");
+
+      const clonedExpenseCount = boot.db
+        .prepare("SELECT COUNT(*) AS count FROM expense_line WHERE scenario_id = ?")
+        .get(clonedScenarioId) as { count: number };
+      expect(clonedExpenseCount.count).toBe(1);
+
+      const clonedRecurrenceCount = boot.db
+        .prepare(
+          `
+            SELECT COUNT(*) AS count
+            FROM recurrence_rule
+            WHERE expense_line_id IN (
+              SELECT id FROM expense_line WHERE scenario_id = ?
+            )
+          `
+        )
+        .get(clonedScenarioId) as { count: number };
+      expect(clonedRecurrenceCount.count).toBe(1);
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("rejects edits for locked scenarios", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const vendorId = repo.createVendor({ name: "Vendor" });
+      const serviceId = repo.createService({ vendorId, name: "Service", status: "active" });
+      const scenarioId = repo.createScenario({ name: "Locked Scenario", approvalStatus: "reviewed" });
+
+      repo.lockScenario(scenarioId);
+
+      expect(() =>
+        repo.createExpenseLineWithOptionalRecurrence({
+          scenarioId,
+          serviceId,
+          name: "Blocked Expense",
+          expenseType: "one_time",
+          status: "planned",
+          amountMinor: 1000,
+          currency: "USD",
+          startDate: "2026-01-01"
+        })
+      ).toThrow(`Scenario is locked: ${scenarioId}`);
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("enforces scenario approval transitions", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const scenarioId = repo.createScenario({ name: "Approvals", approvalStatus: "draft" });
+
+      repo.setScenarioApprovalStatus(scenarioId, "reviewed");
+      repo.setScenarioApprovalStatus(scenarioId, "approved");
+
+      const statusRow = boot.db
+        .prepare("SELECT approval_status FROM scenario WHERE id = ?")
+        .get(scenarioId) as { approval_status: string };
+      expect(statusRow.approval_status).toBe("approved");
+
+      expect(() => repo.setScenarioApprovalStatus(scenarioId, "draft")).toThrow(
+        "Invalid scenario approval transition: approved -> draft"
+      );
+    } finally {
+      boot.db.close();
+    }
+  });
+});
+

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -11,6 +11,16 @@ export const meta = sqliteTable("meta", {
   updatedAt: text("updated_at").notNull()
 });
 
+export const scenario = sqliteTable("scenario", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  parentScenarioId: text("parent_scenario_id"),
+  approvalStatus: text("approval_status").notNull(),
+  isLocked: integer("is_locked").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at").notNull()
+});
+
 export const vendor = sqliteTable("vendor", {
   id: text("id").primaryKey(),
   name: text("name").notNull(),


### PR DESCRIPTION
## Summary
- introduced scenario table/migration with approval status and lock marker support
- added repository APIs for scenario create/clone/lock and approval transition rules
- enforced lock checks in expense and recurrence mutation paths
- added scenario test suite for clone integrity, lock rejection, and approval transition validation
- expanded renderer scenario panel for clone, approval progression, and lock markers

## Verification
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Closes #17