### PR TITLE
C1: Alert rule catalog and scheduler job runner

### DIFF
--- a/packages/db/migrations/006_alert_dedupe.sql
+++ b/packages/db/migrations/006_alert_dedupe.sql
@@ -1,0 +1,6 @@
+CREATE UNIQUE INDEX IF NOT EXISTS idx_alert_event_dedupe_key ON alert_event (dedupe_key);
+
+UPDATE meta
+SET schema_version = 6,
+    updated_at = CURRENT_TIMESTAMP;
+

--- a/packages/db/src/alert-engine.test.ts
+++ b/packages/db/src/alert-engine.test.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runAlertSchedulerTick } from "./alert-engine";
+import { bootstrapEncryptedDatabase } from "./encrypted-db";
+import { runMigrations } from "./migrations";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-alerts-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function seedAlertFixtures(db: ReturnType<typeof bootstrapEncryptedDatabase>["db"]): void {
+  db.prepare(
+    `
+      INSERT INTO occurrence (
+        id, scenario_id, expense_line_id, occurrence_date, amount_minor, currency, state, created_at, updated_at
+      ) VALUES ('occ-1', 'baseline', 'exp-1', '2026-01-10', 10000, 'USD', 'forecast', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `
+  ).run();
+
+  db.prepare(
+    `
+      INSERT INTO contract (
+        id, service_id, contract_number, start_date, end_date, renewal_type, renewal_date, notice_period_days, created_at, updated_at, deleted_at
+      ) VALUES ('contract-1', 'svc-1', 'C-1', '2025-01-01', '2026-12-31', 'auto', '2026-01-20', 10, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL)
+    `
+  ).run();
+
+  db.prepare(
+    `
+      INSERT INTO service_plan (
+        id, scenario_id, service_id, planned_action, decision_status, reason_code, must_replace_by, replacement_required, replacement_selected_service_id, created_at, updated_at
+      ) VALUES
+        ('plan-replacement', 'baseline', 'svc-1', 'replace', 'proposed', 'other', '2026-01-25', 1, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        ('plan-eol', 'baseline', 'svc-2', 'replace', 'proposed', 'EOL', '2026-01-15', 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `
+  ).run();
+
+  const insertRule = db.prepare(
+    `
+      INSERT INTO alert_rule (
+        id, scenario_id, rule_type, params_json, enabled, channels, created_at, updated_at
+      ) VALUES (?, 'baseline', ?, '{\"window_days\":30}', 1, 'in_app', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `
+  );
+
+  insertRule.run("rule-upcoming", "upcoming_payment");
+  insertRule.run("rule-renewal", "renewal_window");
+  insertRule.run("rule-notice", "notice_window");
+  insertRule.run("rule-replacement", "replacement_missing");
+  insertRule.run("rule-eol", "eol_date");
+}
+
+describe("alert scheduler", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("generates expected rule-based alerts and dedupes repeat ticks", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      seedAlertFixtures(boot.db);
+
+      const first = runAlertSchedulerTick(boot.db, "2026-01-01");
+      expect(first.evaluatedRules).toBe(5);
+      expect(first.created).toBe(5);
+
+      const second = runAlertSchedulerTick(boot.db, "2026-01-01");
+      expect(second.created).toBe(0);
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("computes cancellation notice deadline from renewal date minus notice window", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      seedAlertFixtures(boot.db);
+
+      runAlertSchedulerTick(boot.db, "2026-01-01");
+
+      const noticeEvent = boot.db
+        .prepare("SELECT fire_at FROM alert_event WHERE alert_rule_id = 'rule-notice'")
+        .get() as { fire_at: string };
+      expect(noticeEvent.fire_at).toBe("2026-01-10");
+    } finally {
+      boot.db.close();
+    }
+  });
+});
+

--- a/packages/db/src/alert-engine.ts
+++ b/packages/db/src/alert-engine.ts
@@ -1,0 +1,295 @@
+import crypto from "node:crypto";
+
+import type Database from "better-sqlite3-multiple-ciphers";
+
+type AlertRuleType =
+  | "upcoming_payment"
+  | "renewal_window"
+  | "notice_window"
+  | "replacement_missing"
+  | "eol_date";
+
+type AlertRuleRow = {
+  id: string;
+  scenario_id: string;
+  rule_type: AlertRuleType;
+  params_json: string;
+  enabled: number;
+};
+
+type AlertCandidate = {
+  scenarioId: string;
+  ruleId: string;
+  ruleType: AlertRuleType;
+  entityType: string;
+  entityId: string;
+  fireAt: string;
+  message: string;
+};
+
+type AlertParams = {
+  window_days?: number;
+};
+
+function parseIsoDate(dateText: string): Date {
+  return new Date(`${dateText}T00:00:00.000Z`);
+}
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function subtractDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() - days);
+  return next;
+}
+
+function parseParams(paramsJson: string): AlertParams {
+  try {
+    return JSON.parse(paramsJson) as AlertParams;
+  } catch {
+    return {};
+  }
+}
+
+function buildDedupeKey(candidate: AlertCandidate): string {
+  return [
+    candidate.ruleId,
+    candidate.ruleType,
+    candidate.entityType,
+    candidate.entityId,
+    candidate.fireAt
+  ].join("|");
+}
+
+function createNoticeWindowCandidates(
+  db: Database.Database,
+  rule: AlertRuleRow,
+  cutoffIso: string,
+  nowIso: string
+): AlertCandidate[] {
+  const contracts = db
+    .prepare(
+      `
+        SELECT id, renewal_date, notice_period_days
+        FROM contract
+        WHERE renewal_date IS NOT NULL
+          AND notice_period_days IS NOT NULL
+      `
+    )
+    .all() as Array<{ id: string; renewal_date: string; notice_period_days: number }>;
+
+  const cutoffDate = parseIsoDate(cutoffIso);
+  const nowDate = parseIsoDate(nowIso);
+  const candidates: AlertCandidate[] = [];
+
+  for (const contract of contracts) {
+    const renewalDate = parseIsoDate(contract.renewal_date);
+    const deadline = subtractDays(renewalDate, contract.notice_period_days);
+    if (deadline >= nowDate && deadline <= cutoffDate) {
+      candidates.push({
+        scenarioId: rule.scenario_id,
+        ruleId: rule.id,
+        ruleType: rule.rule_type,
+        entityType: "contract",
+        entityId: contract.id,
+        fireAt: toIsoDate(deadline),
+        message: `Cancellation notice deadline approaching for contract ${contract.id}`
+      });
+    }
+  }
+
+  return candidates;
+}
+
+function collectCandidatesForRule(
+  db: Database.Database,
+  rule: AlertRuleRow,
+  nowIso: string
+): AlertCandidate[] {
+  const params = parseParams(rule.params_json);
+  const windowDays = params.window_days ?? 30;
+  const cutoffIso = toIsoDate(addDays(parseIsoDate(nowIso), windowDays));
+
+  if (rule.rule_type === "upcoming_payment") {
+    const rows = db
+      .prepare(
+        `
+          SELECT id, occurrence_date
+          FROM occurrence
+          WHERE scenario_id = ?
+            AND occurrence_date BETWEEN ? AND ?
+        `
+      )
+      .all(rule.scenario_id, nowIso, cutoffIso) as Array<{ id: string; occurrence_date: string }>;
+
+    return rows.map((row) => ({
+      scenarioId: rule.scenario_id,
+      ruleId: rule.id,
+      ruleType: rule.rule_type,
+      entityType: "occurrence",
+      entityId: row.id,
+      fireAt: row.occurrence_date,
+      message: `Upcoming payment on ${row.occurrence_date}`
+    }));
+  }
+
+  if (rule.rule_type === "renewal_window") {
+    const rows = db
+      .prepare(
+        `
+          SELECT id, renewal_date
+          FROM contract
+          WHERE renewal_date BETWEEN ? AND ?
+        `
+      )
+      .all(nowIso, cutoffIso) as Array<{ id: string; renewal_date: string }>;
+
+    return rows.map((row) => ({
+      scenarioId: rule.scenario_id,
+      ruleId: rule.id,
+      ruleType: rule.rule_type,
+      entityType: "contract",
+      entityId: row.id,
+      fireAt: row.renewal_date,
+      message: `Contract renewal approaching on ${row.renewal_date}`
+    }));
+  }
+
+  if (rule.rule_type === "notice_window") {
+    return createNoticeWindowCandidates(db, rule, cutoffIso, nowIso);
+  }
+
+  if (rule.rule_type === "replacement_missing") {
+    const rows = db
+      .prepare(
+        `
+          SELECT id, must_replace_by
+          FROM service_plan
+          WHERE scenario_id = ?
+            AND replacement_required = 1
+            AND replacement_selected_service_id IS NULL
+            AND must_replace_by IS NOT NULL
+            AND must_replace_by BETWEEN ? AND ?
+        `
+      )
+      .all(rule.scenario_id, nowIso, cutoffIso) as Array<{ id: string; must_replace_by: string }>;
+
+    return rows.map((row) => ({
+      scenarioId: rule.scenario_id,
+      ruleId: rule.id,
+      ruleType: rule.rule_type,
+      entityType: "service_plan",
+      entityId: row.id,
+      fireAt: row.must_replace_by,
+      message: `Replacement missing for service plan ${row.id}`
+    }));
+  }
+
+  const rows = db
+    .prepare(
+      `
+        SELECT id, must_replace_by
+        FROM service_plan
+        WHERE scenario_id = ?
+          AND reason_code = 'EOL'
+          AND must_replace_by IS NOT NULL
+          AND must_replace_by BETWEEN ? AND ?
+      `
+    )
+    .all(rule.scenario_id, nowIso, cutoffIso) as Array<{ id: string; must_replace_by: string }>;
+
+  return rows.map((row) => ({
+    scenarioId: rule.scenario_id,
+    ruleId: rule.id,
+    ruleType: rule.rule_type,
+    entityType: "service_plan",
+    entityId: row.id,
+    fireAt: row.must_replace_by,
+    message: `EOL milestone approaching for service plan ${row.id}`
+  }));
+}
+
+function persistCandidates(db: Database.Database, candidates: AlertCandidate[]): number {
+  const insert = db.prepare(
+    `
+      INSERT INTO alert_event (
+        id,
+        scenario_id,
+        alert_rule_id,
+        entity_type,
+        entity_id,
+        fire_at,
+        fired_at,
+        status,
+        dedupe_key,
+        message,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, NULL, 'pending', ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `
+  );
+
+  let created = 0;
+  for (const candidate of candidates) {
+    const dedupeKey = buildDedupeKey(candidate);
+    const existing = db
+      .prepare("SELECT id FROM alert_event WHERE dedupe_key = ?")
+      .get(dedupeKey) as { id: string } | undefined;
+
+    if (existing) {
+      continue;
+    }
+
+    insert.run(
+      crypto.randomUUID(),
+      candidate.scenarioId,
+      candidate.ruleId,
+      candidate.entityType,
+      candidate.entityId,
+      candidate.fireAt,
+      dedupeKey,
+      candidate.message
+    );
+    created += 1;
+  }
+
+  return created;
+}
+
+export function runAlertSchedulerTick(
+  db: Database.Database,
+  nowIsoDate: string = toIsoDate(new Date())
+): { created: number; evaluatedRules: number } {
+  const rules = db
+    .prepare(
+      `
+        SELECT id, scenario_id, rule_type, params_json, enabled
+        FROM alert_rule
+        WHERE enabled = 1
+      `
+    )
+    .all() as AlertRuleRow[];
+
+  const run = db.transaction(() => {
+    let created = 0;
+    for (const rule of rules) {
+      const candidates = collectCandidatesForRule(db, rule, nowIsoDate);
+      created += persistCandidates(db, candidates);
+    }
+    return created;
+  });
+
+  return {
+    created: run(),
+    evaluatedRules: rules.length
+  };
+}
+

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -10,5 +10,6 @@ export { runMigrations, resolveDefaultMigrationsDir } from "./migrations";
 export { updateExpenseLineAmountWithAudit, type UpdateExpenseAmountInput } from "./audit-service";
 export { BudgetCrudRepository, toUsdMinorUnits } from "./repositories";
 export { materializeScenarioOccurrences, markForecastStale } from "./forecast-engine";
+export { runAlertSchedulerTick } from "./alert-engine";
 export * as schema from "./schema";
 

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -37,13 +37,14 @@ describe("migration runner", () => {
         "002_audit_indexes.sql",
         "003_tag_assignment_indexes.sql",
         "004_forecast_state.sql",
-        "005_scenarios.sql"
+        "005_scenarios.sql",
+        "006_alert_dedupe.sql"
       ]);
 
       const metaRow = boot.db
         .prepare("SELECT schema_version, last_mutation_at, forecast_stale FROM meta WHERE id = 1")
         .get() as { schema_version: number; last_mutation_at: string; forecast_stale: number };
-      expect(metaRow.schema_version).toBe(5);
+      expect(metaRow.schema_version).toBe(6);
       expect(metaRow.forecast_stale).toBe(1);
       expect(metaRow.last_mutation_at.length).toBeGreaterThan(0);
     } finally {
@@ -77,7 +78,8 @@ describe("migration runner", () => {
         "002_audit_indexes.sql",
         "003_tag_assignment_indexes.sql",
         "004_forecast_state.sql",
-        "005_scenarios.sql"
+        "005_scenarios.sql",
+        "006_alert_dedupe.sql"
       ]);
 
       const indexRow = boot.db


### PR DESCRIPTION
## Summary
- add alert scheduler engine that evaluates enabled alert rules and persists lert_event rows
- implement rule evaluation for upcoming payments, renewals, notice windows, replacement-missing, and EOL deadlines
- add dedupe key enforcement with migration and scheduler skip logic
- export scheduler API from @budgetit/db

## Testing
- npm run test --workspace @budgetit/db
- npm run lint --workspace @budgetit/db
- npm run typecheck --workspace @budgetit/db

Closes #18