### PR TITLE
C3: Teams Workflows webhook channel integration

### DIFF
--- a/apps/desktop/src/lifecycle.test.ts
+++ b/apps/desktop/src/lifecycle.test.ts
@@ -14,10 +14,14 @@ describe("runtime lifecycle helpers", () => {
 
   it("persists startup preference through merged settings updates", () => {
     const updated = mergeRuntimeSettings(DEFAULT_RUNTIME_SETTINGS, {
-      startWithWindows: false
+      startWithWindows: false,
+      teamsEnabled: true,
+      teamsWebhookUrl: "https://example.invalid/webhook"
     });
     expect(updated.startWithWindows).toBe(false);
     expect(updated.minimizeToTray).toBe(true);
+    expect(updated.teamsEnabled).toBe(true);
+    expect(updated.teamsWebhookUrl).toBe("https://example.invalid/webhook");
   });
 
   it("stops scheduler and quits app when explicit exit is requested", () => {

--- a/apps/desktop/src/lifecycle.ts
+++ b/apps/desktop/src/lifecycle.ts
@@ -1,11 +1,15 @@
 export interface RuntimeSettings {
   startWithWindows: boolean;
   minimizeToTray: boolean;
+  teamsEnabled: boolean;
+  teamsWebhookUrl: string;
 }
 
 export const DEFAULT_RUNTIME_SETTINGS: RuntimeSettings = {
   startWithWindows: true,
-  minimizeToTray: true
+  minimizeToTray: true,
+  teamsEnabled: false,
+  teamsWebhookUrl: ""
 };
 
 export function mergeRuntimeSettings(
@@ -20,7 +24,15 @@ export function mergeRuntimeSettings(
     minimizeToTray:
       typeof update.minimizeToTray === "boolean"
         ? update.minimizeToTray
-        : current.minimizeToTray
+        : current.minimizeToTray,
+    teamsEnabled:
+      typeof update.teamsEnabled === "boolean"
+        ? update.teamsEnabled
+        : current.teamsEnabled,
+    teamsWebhookUrl:
+      typeof update.teamsWebhookUrl === "string"
+        ? update.teamsWebhookUrl
+        : current.teamsWebhookUrl
   };
 }
 

--- a/apps/desktop/src/settings-store.test.ts
+++ b/apps/desktop/src/settings-store.test.ts
@@ -27,18 +27,24 @@ describe("runtime settings persistence", () => {
 
     expect(settings.startWithWindows).toBe(true);
     expect(settings.minimizeToTray).toBe(true);
+    expect(settings.teamsEnabled).toBe(false);
+    expect(settings.teamsWebhookUrl).toBe("");
   });
 
   it("writes and reads updated startup settings", () => {
     const settingsPath = makeTempSettingsPath();
     writeRuntimeSettings(settingsPath, {
       startWithWindows: false,
-      minimizeToTray: true
+      minimizeToTray: true,
+      teamsEnabled: true,
+      teamsWebhookUrl: "https://example.invalid/webhook"
     });
 
     const settings = readRuntimeSettings(settingsPath);
     expect(settings.startWithWindows).toBe(false);
     expect(settings.minimizeToTray).toBe(true);
+    expect(settings.teamsEnabled).toBe(true);
+    expect(settings.teamsWebhookUrl).toBe("https://example.invalid/webhook");
   });
 });
 

--- a/apps/desktop/src/teams-channel.test.ts
+++ b/apps/desktop/src/teams-channel.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTeamsWorkflowPayload, createTeamsWorkflowChannel } from "./teams-channel";
+
+describe("teams workflow channel", () => {
+  it("returns successful test-send and writes delivery log on valid webhook", async () => {
+    const requests: Array<{ url: string; body: string }> = [];
+    const channel = createTeamsWorkflowChannel({
+      fetchImpl: async (url, init) => {
+        requests.push({ url, body: init.body });
+        return { ok: true, status: 202 };
+      },
+      nowIso: () => "2026-03-01T10:00:00.000Z"
+    });
+
+    const result = await channel.sendTest({
+      enabled: true,
+      webhookUrl: "https://example.invalid/teams"
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.attempts).toBe(1);
+    expect(result.health.status).toBe("healthy");
+    expect(channel.getDeliveryLog()).toHaveLength(1);
+    expect(requests[0]?.url).toBe("https://example.invalid/teams");
+  });
+
+  it("retries failures with backoff and transitions health to degraded", async () => {
+    const delays: number[] = [];
+    const channel = createTeamsWorkflowChannel({
+      fetchImpl: async () => {
+        throw new Error("Network unavailable");
+      },
+      sleepImpl: async (delayMs) => {
+        delays.push(delayMs);
+      },
+      nowIso: () => "2026-03-01T11:00:00.000Z",
+      maxAttempts: 3,
+      initialBackoffMs: 100
+    });
+
+    const result = await channel.sendAlert(
+      {
+        enabled: true,
+        webhookUrl: "https://example.invalid/teams"
+      },
+      {
+        title: "Renewal Alert",
+        message: "Renewal for contract-8 is approaching.",
+        entityType: "contract",
+        entityId: "contract-8",
+        fireAt: "2026-03-10"
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.attempts).toBe(3);
+    expect(result.health.status).toBe("degraded");
+    expect(result.health.consecutiveFailures).toBe(1);
+    expect(delays).toEqual([100, 200]);
+  });
+
+  it("formats readable workflow payload text and entity facts", () => {
+    const payload = buildTeamsWorkflowPayload({
+      title: "BudgetIT Renewal Alert",
+      message: "Contract C-102 expires in 30 days.",
+      entityType: "contract",
+      entityId: "C-102",
+      fireAt: "2026-04-01"
+    }) as {
+      attachments: Array<{
+        content: {
+          body: Array<{ text?: string; facts?: Array<{ title: string; value: string }> }>;
+        };
+      }>;
+    };
+
+    const body = payload.attachments[0]?.content.body ?? [];
+    const textBlocks = body.map((entry) => entry.text).filter(Boolean);
+    expect(textBlocks).toContain("BudgetIT Renewal Alert");
+    expect(textBlocks).toContain("Contract C-102 expires in 30 days.");
+
+    const factSet = body.find((entry) => Array.isArray(entry.facts));
+    expect(factSet?.facts).toEqual([
+      { title: "Entity", value: "contract:C-102" },
+      { title: "Scheduled", value: "2026-04-01" }
+    ]);
+  });
+});

--- a/apps/desktop/src/teams-channel.ts
+++ b/apps/desktop/src/teams-channel.ts
@@ -1,0 +1,277 @@
+export type TeamsChannelSettings = {
+  enabled: boolean;
+  webhookUrl: string;
+};
+
+export type TeamsChannelHealth = {
+  status: "unknown" | "healthy" | "degraded";
+  consecutiveFailures: number;
+  lastSuccessAt: string | null;
+  lastFailureAt: string | null;
+  lastError: string | null;
+};
+
+export type TeamsDeliveryLogEntry = {
+  timestamp: string;
+  outcome: "success" | "failure";
+  attempt: number;
+  statusCode: number | null;
+  message: string;
+};
+
+export type TeamsDeliveryResult = {
+  ok: boolean;
+  attempts: number;
+  statusCode: number | null;
+  health: TeamsChannelHealth;
+};
+
+export type TeamsAlertInput = {
+  title: string;
+  message: string;
+  entityType?: string;
+  entityId?: string;
+  fireAt?: string;
+};
+
+type FetchResponseLike = {
+  ok: boolean;
+  status: number;
+};
+
+type FetchLike = (
+  input: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body: string;
+  }
+) => Promise<FetchResponseLike>;
+
+type TeamsChannelDependencies = {
+  fetchImpl?: FetchLike;
+  sleepImpl?: (delayMs: number) => Promise<void>;
+  nowIso?: () => string;
+  maxAttempts?: number;
+  initialBackoffMs?: number;
+};
+
+function defaultSleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+function cloneHealth(health: TeamsChannelHealth): TeamsChannelHealth {
+  return {
+    status: health.status,
+    consecutiveFailures: health.consecutiveFailures,
+    lastSuccessAt: health.lastSuccessAt,
+    lastFailureAt: health.lastFailureAt,
+    lastError: health.lastError
+  };
+}
+
+function stringifyError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export function buildTeamsWorkflowPayload(alert: TeamsAlertInput): Record<string, unknown> {
+  const facts: Array<{ title: string; value: string }> = [];
+  if (alert.entityType && alert.entityId) {
+    facts.push({ title: "Entity", value: `${alert.entityType}:${alert.entityId}` });
+  }
+  if (alert.fireAt) {
+    facts.push({ title: "Scheduled", value: alert.fireAt });
+  }
+
+  return {
+    type: "message",
+    attachments: [
+      {
+        contentType: "application/vnd.microsoft.card.adaptive",
+        content: {
+          $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+          type: "AdaptiveCard",
+          version: "1.4",
+          body: [
+            {
+              type: "TextBlock",
+              size: "Medium",
+              weight: "Bolder",
+              text: alert.title
+            },
+            {
+              type: "TextBlock",
+              wrap: true,
+              text: alert.message
+            },
+            ...(facts.length > 0
+              ? [
+                  {
+                    type: "FactSet",
+                    facts
+                  }
+                ]
+              : [])
+          ]
+        }
+      }
+    ]
+  };
+}
+
+export interface TeamsWorkflowChannel {
+  sendTest: (settings: TeamsChannelSettings) => Promise<TeamsDeliveryResult>;
+  sendAlert: (settings: TeamsChannelSettings, alert: TeamsAlertInput) => Promise<TeamsDeliveryResult>;
+  getHealth: () => TeamsChannelHealth;
+  getDeliveryLog: () => TeamsDeliveryLogEntry[];
+}
+
+export function createTeamsWorkflowChannel(
+  dependencies: TeamsChannelDependencies = {}
+): TeamsWorkflowChannel {
+  const fetchImpl: FetchLike =
+    dependencies.fetchImpl ??
+    (async (input, init) => {
+      const response = await fetch(input, init);
+      return {
+        ok: response.ok,
+        status: response.status
+      };
+    });
+  const sleepImpl = dependencies.sleepImpl ?? defaultSleep;
+  const nowIso = dependencies.nowIso ?? (() => new Date().toISOString());
+  const maxAttempts = dependencies.maxAttempts ?? 3;
+  const initialBackoffMs = dependencies.initialBackoffMs ?? 200;
+
+  const deliveryLog: TeamsDeliveryLogEntry[] = [];
+  const health: TeamsChannelHealth = {
+    status: "unknown",
+    consecutiveFailures: 0,
+    lastSuccessAt: null,
+    lastFailureAt: null,
+    lastError: null
+  };
+
+  async function deliver(
+    settings: TeamsChannelSettings,
+    alert: TeamsAlertInput
+  ): Promise<TeamsDeliveryResult> {
+    const webhookUrl = settings.webhookUrl.trim();
+    if (webhookUrl.length === 0) {
+      throw new Error("Teams webhook URL is required.");
+    }
+
+    const payload = buildTeamsWorkflowPayload(alert);
+    let delayMs = initialBackoffMs;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        const response = await fetchImpl(webhookUrl, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json"
+          },
+          body: JSON.stringify(payload)
+        });
+
+        if (response.ok) {
+          health.status = "healthy";
+          health.consecutiveFailures = 0;
+          health.lastSuccessAt = nowIso();
+          health.lastError = null;
+          deliveryLog.push({
+            timestamp: nowIso(),
+            outcome: "success",
+            attempt,
+            statusCode: response.status,
+            message: `Delivered Teams workflow payload: ${alert.title}`
+          });
+          return {
+            ok: true,
+            attempts: attempt,
+            statusCode: response.status,
+            health: cloneHealth(health)
+          };
+        }
+
+        const failureMessage = `Teams webhook HTTP ${response.status}`;
+        if (attempt === maxAttempts) {
+          health.status = "degraded";
+          health.consecutiveFailures += 1;
+          health.lastFailureAt = nowIso();
+          health.lastError = failureMessage;
+          deliveryLog.push({
+            timestamp: nowIso(),
+            outcome: "failure",
+            attempt,
+            statusCode: response.status,
+            message: failureMessage
+          });
+          return {
+            ok: false,
+            attempts: attempt,
+            statusCode: response.status,
+            health: cloneHealth(health)
+          };
+        }
+      } catch (error) {
+        if (attempt === maxAttempts) {
+          const failureMessage = stringifyError(error);
+          health.status = "degraded";
+          health.consecutiveFailures += 1;
+          health.lastFailureAt = nowIso();
+          health.lastError = failureMessage;
+          deliveryLog.push({
+            timestamp: nowIso(),
+            outcome: "failure",
+            attempt,
+            statusCode: null,
+            message: failureMessage
+          });
+          return {
+            ok: false,
+            attempts: attempt,
+            statusCode: null,
+            health: cloneHealth(health)
+          };
+        }
+      }
+
+      await sleepImpl(delayMs);
+      delayMs *= 2;
+    }
+
+    return {
+      ok: false,
+      attempts: maxAttempts,
+      statusCode: null,
+      health: cloneHealth(health)
+    };
+  }
+
+  return {
+    sendTest: async (settings) =>
+      deliver(settings, {
+        title: "BudgetIT Teams Test",
+        message: "Teams channel test alert from BudgetIT."
+      }),
+    sendAlert: async (settings, alert) => {
+      if (!settings.enabled) {
+        return {
+          ok: false,
+          attempts: 0,
+          statusCode: null,
+          health: cloneHealth(health)
+        };
+      }
+      return deliver(settings, alert);
+    },
+    getHealth: () => cloneHealth(health),
+    getDeliveryLog: () => [...deliveryLog]
+  };
+}


### PR DESCRIPTION
## Summary
- extend runtime settings with 	eamsEnabled and 	eamsWebhookUrl, surfaced in renderer settings UI
- add Teams workflow channel module with adaptive-card payload templates, retry/backoff delivery, and health/degraded state tracking
- wire production alert sends to Teams from the scheduler path and add lerts.sendTest IPC for test delivery
- add unit tests for successful delivery logging, retry/degraded transitions, and readable payload formatting

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Closes #20