### PR TITLE
D1: Encrypted backup creation with manifest and checksum

### DIFF
--- a/packages/db/src/backup.test.ts
+++ b/packages/db/src/backup.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  computeFileSha256,
+  createEncryptedBackup,
+  preflightBackupDestination
+} from "./backup";
+import { bootstrapEncryptedDatabase, openEncryptedDatabase } from "./encrypted-db";
+import { runMigrations } from "./migrations";
+
+const tempRoots: string[] = [];
+
+function createTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("encrypted backup creation", () => {
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("creates encrypted backup that reopens with app key and expected schema", async () => {
+    const dataDir = createTempDir("budgetit-backup-source-");
+    const backupDir = createTempDir("budgetit-backup-target-");
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    runMigrations(boot.db);
+    boot.db
+      .prepare(
+        `
+          INSERT INTO vendor (id, name, website, notes, created_at, updated_at, deleted_at)
+          VALUES ('vendor-1', 'Backup Fixture Vendor', NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL)
+        `
+      )
+      .run();
+    boot.db.close();
+
+    const result = await createEncryptedBackup({
+      sourceDbPath: boot.dbPath,
+      dbKeyHex: boot.keyHex,
+      destinationDir: backupDir,
+      now: new Date("2026-03-20T08:00:00.000Z")
+    });
+
+    const reopened = openEncryptedDatabase(result.backupPath, boot.keyHex);
+    try {
+      const meta = reopened
+        .prepare("SELECT schema_version, last_mutation_at FROM meta WHERE id = 1")
+        .get() as { schema_version: number; last_mutation_at: string };
+      expect(meta.schema_version).toBeGreaterThanOrEqual(1);
+      expect(meta.last_mutation_at.length).toBeGreaterThan(0);
+
+      const vendorCount = reopened
+        .prepare("SELECT COUNT(*) AS total FROM vendor")
+        .get() as { total: number };
+      expect(vendorCount.total).toBe(1);
+    } finally {
+      reopened.close();
+    }
+  });
+
+  it("writes manifest checksum that matches computed backup file hash", async () => {
+    const dataDir = createTempDir("budgetit-backup-source-");
+    const backupDir = createTempDir("budgetit-backup-target-");
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    runMigrations(boot.db);
+    boot.db.close();
+
+    const result = await createEncryptedBackup({
+      sourceDbPath: boot.dbPath,
+      dbKeyHex: boot.keyHex,
+      destinationDir: backupDir,
+      now: new Date("2026-03-20T09:00:00.000Z")
+    });
+
+    const manifestFromDisk = JSON.parse(fs.readFileSync(result.manifestPath, "utf8")) as {
+      checksumSha256: string;
+    };
+    expect(manifestFromDisk.checksumSha256).toBe(computeFileSha256(result.backupPath));
+    expect(result.manifest.checksumSha256).toBe(manifestFromDisk.checksumSha256);
+  });
+
+  it("returns actionable preflight error for unreachable target path", async () => {
+    const dataDir = createTempDir("budgetit-backup-source-");
+    const blockedRoot = createTempDir("budgetit-backup-blocked-");
+    const blockedPath = path.join(blockedRoot, "not-a-directory.txt");
+    fs.writeFileSync(blockedPath, "blocked", "utf8");
+
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    runMigrations(boot.db);
+    boot.db.close();
+
+    expect(() => preflightBackupDestination(blockedPath)).toThrow(
+      "Ensure local/network/external target is mounted and writable."
+    );
+
+    await expect(
+      createEncryptedBackup({
+        sourceDbPath: boot.dbPath,
+        dbKeyHex: boot.keyHex,
+        destinationDir: blockedPath
+      })
+    ).rejects.toThrow("Backup destination preflight failed");
+  });
+});

--- a/packages/db/src/backup.ts
+++ b/packages/db/src/backup.ts
@@ -1,0 +1,147 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { openEncryptedDatabase } from "./encrypted-db";
+
+export type BackupDestinationKind = "local_or_external" | "network";
+
+export type BackupManifest = {
+  manifestVersion: 1;
+  createdAt: string;
+  sourceDbFile: string;
+  backupFile: string;
+  sourceLastMutationAt: string;
+  schemaVersion: number;
+  checksumSha256: string;
+  checksumAlgorithm: "sha256";
+  destinationKind: BackupDestinationKind;
+};
+
+export type CreateEncryptedBackupInput = {
+  sourceDbPath: string;
+  dbKeyHex: string;
+  destinationDir: string;
+  filePrefix?: string;
+  now?: Date;
+};
+
+export type CreateEncryptedBackupResult = {
+  backupPath: string;
+  manifestPath: string;
+  manifest: BackupManifest;
+};
+
+function toTimestampToken(now: Date): string {
+  const iso = now.toISOString().replace(/\.\d{3}Z$/, "Z");
+  return iso.replace(/[:-]/g, "").replace("T", "-").replace("Z", "");
+}
+
+function assertNonEmptyPath(value: string, label: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${label} is required.`);
+  }
+}
+
+function escapeSqlString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+export function classifyBackupDestination(destinationDir: string): BackupDestinationKind {
+  const normalized = destinationDir.trim();
+  if (normalized.startsWith("\\\\")) {
+    return "network";
+  }
+  return "local_or_external";
+}
+
+export function computeFileSha256(filePath: string): string {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+export function preflightBackupDestination(destinationDir: string): BackupDestinationKind {
+  assertNonEmptyPath(destinationDir, "Backup destination");
+
+  const resolved = path.resolve(destinationDir);
+  const destinationKind = classifyBackupDestination(resolved);
+
+  try {
+    if (fs.existsSync(resolved)) {
+      const stat = fs.statSync(resolved);
+      if (!stat.isDirectory()) {
+        throw new Error("Target path exists but is not a directory.");
+      }
+    } else {
+      fs.mkdirSync(resolved, { recursive: true });
+    }
+
+    const probePath = path.join(resolved, `.budgetit-backup-probe-${crypto.randomUUID()}.tmp`);
+    fs.writeFileSync(probePath, "ok", "utf8");
+    fs.rmSync(probePath, { force: true });
+    return destinationKind;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Backup destination preflight failed for ${resolved}. Ensure local/network/external target is mounted and writable. ${detail}`
+    );
+  }
+}
+
+export async function createEncryptedBackup(
+  input: CreateEncryptedBackupInput
+): Promise<CreateEncryptedBackupResult> {
+  assertNonEmptyPath(input.sourceDbPath, "Source database path");
+  assertNonEmptyPath(input.dbKeyHex, "Database key");
+
+  const now = input.now ?? new Date();
+  const destinationKind = preflightBackupDestination(input.destinationDir);
+  const destinationDir = path.resolve(input.destinationDir);
+  const filePrefix = input.filePrefix?.trim() || "budgetit-backup";
+  const token = toTimestampToken(now);
+
+  const backupFileName = `${filePrefix}-${token}.db`;
+  const manifestFileName = `${filePrefix}-${token}.manifest.json`;
+  const backupPath = path.join(destinationDir, backupFileName);
+  const manifestPath = path.join(destinationDir, manifestFileName);
+
+  const source = openEncryptedDatabase(input.sourceDbPath, input.dbKeyHex);
+  try {
+    source.pragma("wal_checkpoint(TRUNCATE)");
+
+    const meta = source
+      .prepare("SELECT schema_version, last_mutation_at FROM meta WHERE id = 1")
+      .get() as { schema_version: number; last_mutation_at: string } | undefined;
+
+    if (!meta) {
+      throw new Error("Meta row was not found; cannot build backup manifest.");
+    }
+
+    const escapedBackupPath = escapeSqlString(backupPath);
+    source.exec(`VACUUM INTO '${escapedBackupPath}';`);
+    const checksumSha256 = computeFileSha256(backupPath);
+
+    const manifest: BackupManifest = {
+      manifestVersion: 1,
+      createdAt: now.toISOString(),
+      sourceDbFile: path.basename(input.sourceDbPath),
+      backupFile: backupFileName,
+      sourceLastMutationAt: meta.last_mutation_at,
+      schemaVersion: meta.schema_version,
+      checksumSha256,
+      checksumAlgorithm: "sha256",
+      destinationKind
+    };
+
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+    return {
+      backupPath,
+      manifestPath,
+      manifest
+    };
+  } finally {
+    source.close();
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -12,6 +12,16 @@ export { BudgetCrudRepository, toUsdMinorUnits } from "./repositories";
 export { materializeScenarioOccurrences, markForecastStale } from "./forecast-engine";
 export { runAlertSchedulerTick } from "./alert-engine";
 export {
+  classifyBackupDestination,
+  computeFileSha256,
+  createEncryptedBackup,
+  preflightBackupDestination,
+  type BackupDestinationKind,
+  type BackupManifest,
+  type CreateEncryptedBackupInput,
+  type CreateEncryptedBackupResult
+} from "./backup";
+export {
   acknowledgeAlertEvent,
   listActionableAlertEventsForNotification,
   listAlertEvents,


### PR DESCRIPTION
## Summary
- add DB backup module for encrypted backup creation with destination preflight checks
- implement backup manifest generation (source_last_mutation_at, schema version, SHA-256 checksum, destination kind)
- add checksum utility + destination classifier/preflight helper
- wire desktop IPC ackup.create to active encrypted DB handle and key
- add tests for backup reopenability, manifest checksum verification, and unreachable destination errors

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Closes #21