### PR TITLE
D2: Restore flow with integrity checks and as-of UX

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "eslint \"src/**/*.{ts,tsx}\" vite.config.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
     "build": "vite build"
   },
   "dependencies": {

--- a/apps/renderer/src/restore-banner.test.ts
+++ b/apps/renderer/src/restore-banner.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRestoreBanner } from "./restore-banner";
+
+describe("restore banner text", () => {
+  it("renders source-as-of and restored timestamps for post-restore UX", () => {
+    const text = formatRestoreBanner({
+      sourceLastMutationAt: "2026-03-20T08:00:00.000Z",
+      restoredAt: "2026-03-20T12:00:00.000Z",
+      schemaVersion: 7
+    });
+
+    expect(text).toContain("Data current as of 2026-03-20T08:00:00.000Z");
+    expect(text).toContain("restored 2026-03-20T12:00:00.000Z");
+  });
+});

--- a/apps/renderer/src/restore-banner.ts
+++ b/apps/renderer/src/restore-banner.ts
@@ -1,0 +1,9 @@
+export type RestoreSummary = {
+  restoredAt: string;
+  sourceLastMutationAt: string;
+  schemaVersion: number;
+};
+
+export function formatRestoreBanner(summary: RestoreSummary): string {
+  return `Data current as of ${summary.sourceLastMutationAt} (restored ${summary.restoredAt})`;
+}

--- a/packages/db/src/backup.test.ts
+++ b/packages/db/src/backup.test.ts
@@ -7,7 +7,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   computeFileSha256,
   createEncryptedBackup,
-  preflightBackupDestination
+  preflightBackupDestination,
+  restoreEncryptedBackup
 } from "./backup";
 import { bootstrapEncryptedDatabase, openEncryptedDatabase } from "./encrypted-db";
 import { runMigrations } from "./migrations";
@@ -108,5 +109,99 @@ describe("encrypted backup creation", () => {
         destinationDir: blockedPath
       })
     ).rejects.toThrow("Backup destination preflight failed");
+  });
+
+  it("restores valid backup and reproduces fixture dataset", async () => {
+    const sourceDataDir = createTempDir("budgetit-restore-source-");
+    const targetDataDir = createTempDir("budgetit-restore-target-");
+    const backupDir = createTempDir("budgetit-restore-backups-");
+
+    const source = bootstrapEncryptedDatabase(sourceDataDir);
+    runMigrations(source.db);
+    source.db
+      .prepare(
+        `
+          INSERT INTO vendor (id, name, website, notes, created_at, updated_at, deleted_at)
+          VALUES ('vendor-source', 'Restored Vendor', NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL)
+        `
+      )
+      .run();
+    source.db.close();
+
+    const backupResult = await createEncryptedBackup({
+      sourceDbPath: source.dbPath,
+      dbKeyHex: source.keyHex,
+      destinationDir: backupDir,
+      now: new Date("2026-03-20T10:00:00.000Z")
+    });
+
+    const target = bootstrapEncryptedDatabase(targetDataDir, source.keyHex);
+    runMigrations(target.db);
+    target.db
+      .prepare(
+        `
+          INSERT INTO vendor (id, name, website, notes, created_at, updated_at, deleted_at)
+          VALUES ('vendor-target', 'Target Vendor', NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL)
+        `
+      )
+      .run();
+    target.db.close();
+
+    const restoreResult = await restoreEncryptedBackup({
+      backupPath: backupResult.backupPath,
+      manifestPath: backupResult.manifestPath,
+      targetDbPath: target.dbPath,
+      dbKeyHex: source.keyHex
+    });
+
+    expect(restoreResult.sourceLastMutationAt).toBe(backupResult.manifest.sourceLastMutationAt);
+    expect(restoreResult.schemaVersion).toBe(backupResult.manifest.schemaVersion);
+
+    const reopened = openEncryptedDatabase(target.dbPath, source.keyHex);
+    try {
+      const vendors = reopened
+        .prepare("SELECT id, name FROM vendor ORDER BY id")
+        .all() as Array<{ id: string; name: string }>;
+      expect(vendors).toEqual([{ id: "vendor-source", name: "Restored Vendor" }]);
+    } finally {
+      reopened.close();
+    }
+  });
+
+  it("blocks restore when backup checksum/integrity validation fails", async () => {
+    const dataDir = createTempDir("budgetit-restore-source-");
+    const targetDataDir = createTempDir("budgetit-restore-target-");
+    const backupDir = createTempDir("budgetit-restore-backups-");
+
+    const source = bootstrapEncryptedDatabase(dataDir);
+    runMigrations(source.db);
+    source.db.close();
+
+    const backupResult = await createEncryptedBackup({
+      sourceDbPath: source.dbPath,
+      dbKeyHex: source.keyHex,
+      destinationDir: backupDir,
+      now: new Date("2026-03-20T11:00:00.000Z")
+    });
+
+    const target = bootstrapEncryptedDatabase(targetDataDir, source.keyHex);
+    runMigrations(target.db);
+    target.db.close();
+
+    const fileHandle = fs.openSync(backupResult.backupPath, "r+");
+    try {
+      fs.writeSync(fileHandle, Buffer.from("CORRUPTED"), 0, 8, 0);
+    } finally {
+      fs.closeSync(fileHandle);
+    }
+
+    await expect(
+      restoreEncryptedBackup({
+        backupPath: backupResult.backupPath,
+        manifestPath: backupResult.manifestPath,
+        targetDbPath: target.dbPath,
+        dbKeyHex: source.keyHex
+      })
+    ).rejects.toThrow("Backup checksum mismatch");
   });
 });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -16,10 +16,16 @@ export {
   computeFileSha256,
   createEncryptedBackup,
   preflightBackupDestination,
+  readBackupManifest,
+  restoreEncryptedBackup,
+  verifyEncryptedBackup,
   type BackupDestinationKind,
+  type BackupIntegrityResult,
   type BackupManifest,
   type CreateEncryptedBackupInput,
-  type CreateEncryptedBackupResult
+  type CreateEncryptedBackupResult,
+  type RestoreEncryptedBackupInput,
+  type RestoreEncryptedBackupResult
 } from "./backup";
 export {
   acknowledgeAlertEvent,


### PR DESCRIPTION
## Summary
- add backup restore APIs: manifest read, checksum verification, integrity_check validation, schema compatibility guard, and target DB restore
- wire desktop IPC ackup.restore with safe DB close/reopen lifecycle around restore operations
- add renderer restore UI inputs (ackupPath + manifestPath) and restore action
- show a post-restore as-of banner using returned restore metadata (sourceLastMutationAt + estoredAt)
- expand backup tests to cover valid restore reproduction and corrupted backup blocking

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Closes #22