### PR TITLE
feat: implement E1 csv/xlsx ingest wizard with validation and dedupe

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@budgetit/core": "*",
     "@budgetit/db": "^0.1.0",
-    "electron": "^35.0.1"
+    "electron": "^35.0.1",
+    "xlsx": "^0.18.5"
   }
 }

--- a/apps/desktop/src/import-wizard.test.ts
+++ b/apps/desktop/src/import-wizard.test.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { bootstrapEncryptedDatabase, runMigrations, BudgetCrudRepository } from "@budgetit/db";
+import { afterEach, describe, expect, it } from "vitest";
+import * as XLSX from "xlsx";
+
+import { commitExpenseImport, previewExpenseImport } from "./import-wizard";
+
+const tempRoots: string[] = [];
+
+function createTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function createCsv(filePath: string, lines: string[]): void {
+  fs.writeFileSync(filePath, `${lines.join("\n")}\n`, "utf8");
+}
+
+function createXlsx(filePath: string, rows: string[][]): void {
+  const workbook = XLSX.utils.book_new();
+  const sheet = XLSX.utils.aoa_to_sheet(rows);
+  XLSX.utils.book_append_sheet(workbook, sheet, "Import");
+  XLSX.writeFile(workbook, filePath);
+}
+
+function seedService(repo: BudgetCrudRepository): string {
+  const vendorId = repo.createVendor({ name: "Import Vendor" });
+  return repo.createService({
+    vendorId,
+    name: "Import Service",
+    status: "active"
+  });
+}
+
+describe("import wizard", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns expected accepted and rejected counts for mixed-validity rows", () => {
+    const dataDir = createTempDir("budgetit-import-db-");
+    const fixtureDir = createTempDir("budgetit-import-fixture-");
+    const boot = bootstrapEncryptedDatabase(dataDir);
+
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const serviceId = seedService(repo);
+
+      const csvPath = path.join(fixtureDir, "mixed.csv");
+      createCsv(csvPath, [
+        "scenario_id,service_id,name,expense_type,status,amount,currency,frequency,day_of_month,interval",
+        `baseline,${serviceId},Email Licenses,recurring,planned,100.00,USD,monthly,1,1`,
+        `baseline,${serviceId},Invalid Amount,one_time,planned,abc,USD,,,`,
+        `baseline,${serviceId},Missing Type,,planned,20.00,USD,,,`,
+        `baseline,${serviceId},Email Licenses,recurring,planned,100.00,USD,monthly,1,1`
+      ]);
+
+      const preview = previewExpenseImport(boot.db, {
+        filePath: csvPath,
+        templateStorePath: path.join(fixtureDir, "templates.json")
+      });
+
+      expect(preview.totalRows).toBe(4);
+      expect(preview.acceptedCount).toBe(1);
+      expect(preview.rejectedCount).toBe(3);
+      expect(preview.duplicateCount).toBe(1);
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("reuses a saved mapping template across sessions", () => {
+    const dataDir = createTempDir("budgetit-import-db-");
+    const fixtureDir = createTempDir("budgetit-import-fixture-");
+    const boot = bootstrapEncryptedDatabase(dataDir);
+
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const serviceId = seedService(repo);
+      const workbookPath = path.join(fixtureDir, "custom-columns.xlsx");
+      const templateStorePath = path.join(fixtureDir, "templates.json");
+
+      createXlsx(workbookPath, [
+        ["Scenario", "Service", "Expense", "Type", "State", "AmountUSD"],
+        ["baseline", serviceId, "Office Suite", "one_time", "planned", "49.95"]
+      ]);
+
+      const first = previewExpenseImport(boot.db, {
+        filePath: workbookPath,
+        templateStorePath,
+        saveTemplate: true,
+        templateName: "accounting-format",
+        mapping: {
+          scenarioId: "Scenario",
+          serviceId: "Service",
+          name: "Expense",
+          expenseType: "Type",
+          status: "State",
+          amount: "AmountUSD"
+        }
+      });
+
+      expect(first.acceptedCount).toBe(1);
+      expect(first.templateSaved).toBe("accounting-format");
+
+      const second = previewExpenseImport(boot.db, {
+        filePath: workbookPath,
+        templateStorePath,
+        useSavedTemplate: true,
+        templateName: "accounting-format"
+      });
+
+      expect(second.acceptedCount).toBe(1);
+      expect(second.templateApplied).toBe("accounting-format");
+      expect(second.mapping.status).toBe("State");
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("applies deterministic duplicate policy on repeated commit", () => {
+    const dataDir = createTempDir("budgetit-import-db-");
+    const fixtureDir = createTempDir("budgetit-import-fixture-");
+    const boot = bootstrapEncryptedDatabase(dataDir);
+
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const serviceId = seedService(repo);
+
+      const csvPath = path.join(fixtureDir, "dedupe.csv");
+      createCsv(csvPath, [
+        "scenario_id,service_id,name,expense_type,status,amount,currency",
+        `baseline,${serviceId},Monitoring,one_time,approved,150.00,USD`
+      ]);
+
+      const first = commitExpenseImport(boot.db, {
+        filePath: csvPath,
+        templateStorePath: path.join(fixtureDir, "templates.json")
+      });
+      const second = commitExpenseImport(boot.db, {
+        filePath: csvPath,
+        templateStorePath: path.join(fixtureDir, "templates.json")
+      });
+
+      const countRow = boot.db
+        .prepare("SELECT COUNT(*) AS count FROM expense_line WHERE deleted_at IS NULL")
+        .get() as { count: number };
+
+      expect(first.insertedCount).toBe(1);
+      expect(second.insertedCount).toBe(0);
+      expect(second.duplicateCount).toBe(1);
+      expect(second.skippedDuplicateCount).toBe(1);
+      expect(countRow.count).toBe(1);
+    } finally {
+      boot.db.close();
+    }
+  });
+});

--- a/apps/desktop/src/import-wizard.ts
+++ b/apps/desktop/src/import-wizard.ts
@@ -1,0 +1,819 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { BudgetCrudRepository, toUsdMinorUnits } from "@budgetit/db";
+import type Database from "better-sqlite3-multiple-ciphers";
+import * as XLSX from "xlsx";
+
+export type ImportField =
+  | "scenarioId"
+  | "serviceId"
+  | "contractId"
+  | "name"
+  | "expenseType"
+  | "status"
+  | "amount"
+  | "currency"
+  | "startDate"
+  | "endDate"
+  | "frequency"
+  | "interval"
+  | "dayOfMonth"
+  | "monthOfYear"
+  | "anchorDate";
+
+export type ImportColumnMapping = Partial<Record<ImportField, string>>;
+
+type ExpenseType = "recurring" | "one_time";
+type ExpenseStatus = "planned" | "approved" | "committed" | "actual" | "cancelled";
+type Frequency = "monthly" | "quarterly" | "yearly";
+
+type RecurrenceInput = {
+  frequency: Frequency;
+  interval: number;
+  dayOfMonth: number;
+  monthOfYear?: number;
+  anchorDate?: string;
+};
+
+export type NormalizedImportRow = {
+  rowNumber: number;
+  scenarioId: string;
+  serviceId: string;
+  contractId?: string;
+  name: string;
+  expenseType: ExpenseType;
+  status: ExpenseStatus;
+  amountMinor: number;
+  currency: "USD";
+  startDate?: string;
+  endDate?: string;
+  recurrence?: RecurrenceInput;
+  fingerprint: string;
+};
+
+export type ImportRowError = {
+  rowNumber: number;
+  code: "validation" | "duplicate";
+  field: ImportField | "row";
+  message: string;
+};
+
+export type ImportPreviewInput = {
+  filePath: string;
+  mapping?: ImportColumnMapping;
+  templateName?: string;
+  useSavedTemplate?: boolean;
+  saveTemplate?: boolean;
+  templateStorePath: string;
+};
+
+export type ImportPreviewResult = {
+  totalRows: number;
+  acceptedCount: number;
+  rejectedCount: number;
+  duplicateCount: number;
+  mapping: ImportColumnMapping;
+  templateApplied: string | null;
+  templateSaved: string | null;
+  errors: ImportRowError[];
+  acceptedRows: NormalizedImportRow[];
+};
+
+export type ImportCommitResult = {
+  totalRows: number;
+  acceptedCount: number;
+  rejectedCount: number;
+  duplicateCount: number;
+  insertedCount: number;
+  skippedDuplicateCount: number;
+  errors: ImportRowError[];
+};
+
+type TemplateStore = {
+  templates: Array<{
+    name: string;
+    headerSignature: string;
+    mapping: ImportColumnMapping;
+    updatedAt: string;
+  }>;
+};
+
+const REQUIRED_FIELDS: ImportField[] = [
+  "scenarioId",
+  "serviceId",
+  "name",
+  "expenseType",
+  "status",
+  "amount"
+];
+
+const FIELD_ALIASES: Record<ImportField, string[]> = {
+  scenarioId: ["scenario_id", "scenario", "scenarioid"],
+  serviceId: ["service_id", "service", "serviceid"],
+  contractId: ["contract_id", "contract", "contractid"],
+  name: ["name", "expense", "expense_name", "line_item"],
+  expenseType: ["expense_type", "type"],
+  status: ["status"],
+  amount: ["amount", "amount_usd", "usd", "cost", "price"],
+  currency: ["currency", "curr"],
+  startDate: ["start_date", "start"],
+  endDate: ["end_date", "end"],
+  frequency: ["frequency", "recurrence"],
+  interval: ["interval", "every"],
+  dayOfMonth: ["day_of_month", "day", "dom"],
+  monthOfYear: ["month_of_year", "month", "moy"],
+  anchorDate: ["anchor_date", "anchor"]
+};
+
+function normalizeHeaderName(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, "_");
+}
+
+function isIsoDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime());
+}
+
+function sha256(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function parseIntStrict(value: string): number | null {
+  if (!/^-?\d+$/.test(value.trim())) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function parseCsvLine(line: string): string[] {
+  const values: string[] = [];
+  let current = "";
+  let insideQuotes = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === "\"") {
+      if (insideQuotes && line[index + 1] === "\"") {
+        current += "\"";
+        index += 1;
+      } else {
+        insideQuotes = !insideQuotes;
+      }
+      continue;
+    }
+
+    if (char === "," && !insideQuotes) {
+      values.push(current);
+      current = "";
+      continue;
+    }
+
+    current += char;
+  }
+
+  values.push(current);
+  return values.map((entry) => entry.trim());
+}
+
+function readCsvRows(filePath: string): { headers: string[]; rows: Record<string, string>[] } {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return { headers: [], rows: [] };
+  }
+
+  const headers = parseCsvLine(lines[0]);
+  const rows = lines.slice(1).map((line) => {
+    const cells = parseCsvLine(line);
+    const record: Record<string, string> = {};
+    for (let index = 0; index < headers.length; index += 1) {
+      record[headers[index]] = cells[index] ?? "";
+    }
+    return record;
+  });
+
+  return { headers, rows };
+}
+
+function readXlsxRows(filePath: string): { headers: string[]; rows: Record<string, string>[] } {
+  const workbook = XLSX.readFile(filePath, { cellDates: false });
+  const firstSheetName = workbook.SheetNames[0];
+  if (!firstSheetName) {
+    return { headers: [], rows: [] };
+  }
+
+  const sheet = workbook.Sheets[firstSheetName];
+  const matrix = XLSX.utils.sheet_to_json<Array<string | number | boolean | null>>(sheet, {
+    header: 1,
+    defval: ""
+  });
+  if (matrix.length === 0) {
+    return { headers: [], rows: [] };
+  }
+
+  const headers = matrix[0].map((value) => String(value ?? "").trim());
+  const rows = matrix.slice(1).map((line) => {
+    const record: Record<string, string> = {};
+    for (let index = 0; index < headers.length; index += 1) {
+      record[headers[index]] = String(line[index] ?? "").trim();
+    }
+    return record;
+  });
+
+  return { headers, rows };
+}
+
+function readImportRows(filePath: string): { headers: string[]; rows: Record<string, string>[] } {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === ".csv") {
+    return readCsvRows(filePath);
+  }
+  if (extension === ".xlsx") {
+    return readXlsxRows(filePath);
+  }
+  throw new Error("Unsupported import file type. Use .csv or .xlsx.");
+}
+
+function loadTemplateStore(filePath: string): TemplateStore {
+  if (!fs.existsSync(filePath)) {
+    return { templates: [] };
+  }
+  const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as Partial<TemplateStore>;
+  if (!Array.isArray(parsed.templates)) {
+    return { templates: [] };
+  }
+  return {
+    templates: parsed.templates.filter((entry): entry is TemplateStore["templates"][number] => {
+      return (
+        typeof entry?.name === "string" &&
+        typeof entry?.headerSignature === "string" &&
+        typeof entry?.mapping === "object" &&
+        entry.mapping !== null &&
+        typeof entry?.updatedAt === "string"
+      );
+    })
+  };
+}
+
+function saveTemplateStore(filePath: string, store: TemplateStore): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+}
+
+function headerSignature(headers: string[]): string {
+  return headers.map(normalizeHeaderName).join("|");
+}
+
+function buildAutoMapping(headers: string[]): ImportColumnMapping {
+  const byNormalizedName = new Map<string, string>();
+  for (const header of headers) {
+    byNormalizedName.set(normalizeHeaderName(header), header);
+  }
+
+  const mapping: ImportColumnMapping = {};
+  const fields = Object.keys(FIELD_ALIASES) as ImportField[];
+  for (const field of fields) {
+    for (const alias of FIELD_ALIASES[field]) {
+      const candidate = byNormalizedName.get(alias);
+      if (candidate) {
+        mapping[field] = candidate;
+        break;
+      }
+    }
+  }
+  return mapping;
+}
+
+function normalizeMapping(headers: string[], mapping: ImportColumnMapping): ImportColumnMapping {
+  const headerSet = new Set(headers);
+  const normalized: ImportColumnMapping = {};
+  const fields = Object.keys(mapping) as ImportField[];
+  for (const field of fields) {
+    const column = mapping[field];
+    if (!column || !headerSet.has(column)) {
+      continue;
+    }
+    normalized[field] = column;
+  }
+  return normalized;
+}
+
+function resolveMapping(
+  headers: string[],
+  input: ImportPreviewInput
+): { mapping: ImportColumnMapping; templateApplied: string | null; templateSaved: string | null } {
+  const signature = headerSignature(headers);
+  const requested = input.mapping ? normalizeMapping(headers, input.mapping) : {};
+  const store = loadTemplateStore(input.templateStorePath);
+  let mapping: ImportColumnMapping = { ...requested };
+  let templateApplied: string | null = null;
+
+  const hasRequestedMapping = Object.keys(requested).length > 0;
+  const shouldUseTemplate = input.useSavedTemplate !== false && !hasRequestedMapping;
+  if (shouldUseTemplate) {
+    const template = store.templates.find((entry) => {
+      if (input.templateName) {
+        return entry.name === input.templateName;
+      }
+      return entry.headerSignature === signature;
+    });
+    if (template) {
+      mapping = normalizeMapping(headers, template.mapping);
+      templateApplied = template.name;
+    }
+  }
+
+  if (Object.keys(mapping).length === 0) {
+    mapping = buildAutoMapping(headers);
+  }
+
+  let templateSaved: string | null = null;
+  if (input.saveTemplate) {
+    const name = input.templateName?.trim() || `template:${signature}`;
+    const updatedAt = new Date().toISOString();
+    const nextStore: TemplateStore = {
+      templates: store.templates.filter((entry) => entry.name !== name).concat({
+        name,
+        headerSignature: signature,
+        mapping,
+        updatedAt
+      })
+    };
+    saveTemplateStore(input.templateStorePath, nextStore);
+    templateSaved = name;
+  }
+
+  return { mapping, templateApplied, templateSaved };
+}
+
+function buildFingerprint(row: Omit<NormalizedImportRow, "fingerprint" | "rowNumber">): string {
+  const recurrenceToken = row.recurrence
+    ? `${row.recurrence.frequency}|${row.recurrence.interval}|${row.recurrence.dayOfMonth}|${row.recurrence.monthOfYear ?? ""}|${row.recurrence.anchorDate ?? ""}`
+    : "";
+  const token = [
+    row.scenarioId,
+    row.serviceId,
+    row.contractId ?? "",
+    row.name.toLowerCase(),
+    row.expenseType,
+    row.status,
+    String(row.amountMinor),
+    row.currency,
+    row.startDate ?? "",
+    row.endDate ?? "",
+    recurrenceToken
+  ].join("|");
+  return sha256(token);
+}
+
+function rowValue(row: Record<string, string>, mapping: ImportColumnMapping, field: ImportField): string {
+  const column = mapping[field];
+  if (!column) {
+    return "";
+  }
+  return (row[column] ?? "").trim();
+}
+
+function normalizeRow(
+  row: Record<string, string>,
+  rowNumber: number,
+  mapping: ImportColumnMapping
+): { value?: NormalizedImportRow; errors: ImportRowError[] } {
+  const errors: ImportRowError[] = [];
+  const scenarioId = rowValue(row, mapping, "scenarioId");
+  const serviceId = rowValue(row, mapping, "serviceId");
+  const contractId = rowValue(row, mapping, "contractId");
+  const name = rowValue(row, mapping, "name");
+  const expenseTypeRaw = rowValue(row, mapping, "expenseType").toLowerCase();
+  const statusRaw = rowValue(row, mapping, "status").toLowerCase();
+  const amountRaw = rowValue(row, mapping, "amount");
+  const currencyRaw = rowValue(row, mapping, "currency").toUpperCase() || "USD";
+  const startDate = rowValue(row, mapping, "startDate");
+  const endDate = rowValue(row, mapping, "endDate");
+  const frequencyRaw = rowValue(row, mapping, "frequency").toLowerCase();
+  const intervalRaw = rowValue(row, mapping, "interval");
+  const dayOfMonthRaw = rowValue(row, mapping, "dayOfMonth");
+  const monthOfYearRaw = rowValue(row, mapping, "monthOfYear");
+  const anchorDate = rowValue(row, mapping, "anchorDate");
+
+  for (const field of REQUIRED_FIELDS) {
+    if (!mapping[field]) {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field,
+        message: `Missing mapping for required field: ${field}`
+      });
+    }
+  }
+
+  if (!scenarioId) {
+    errors.push({
+      rowNumber,
+      code: "validation",
+      field: "scenarioId",
+      message: "scenarioId is required."
+    });
+  }
+  if (!serviceId) {
+    errors.push({
+      rowNumber,
+      code: "validation",
+      field: "serviceId",
+      message: "serviceId is required."
+    });
+  }
+  if (!name) {
+    errors.push({
+      rowNumber,
+      code: "validation",
+      field: "name",
+      message: "name is required."
+    });
+  }
+
+  let expenseType: ExpenseType | null = null;
+  if (expenseTypeRaw === "recurring" || expenseTypeRaw === "one_time") {
+    expenseType = expenseTypeRaw;
+  } else {
+    errors.push({
+      rowNumber,
+      code: "validation",
+      field: "expenseType",
+      message: "expenseType must be recurring or one_time."
+    });
+  }
+
+  let status: ExpenseStatus | null = null;
+  if (
+    statusRaw === "planned" ||
+    statusRaw === "approved" ||
+    statusRaw === "committed" ||
+    statusRaw === "actual" ||
+    statusRaw === "cancelled"
+  ) {
+    status = statusRaw;
+  } else {
+    errors.push({
+      rowNumber,
+      code: "validation",
+      field: "status",
+      message: "status is invalid."
+    });
+  }
+
+  let amountMinor = 0;
+  try {
+    amountMinor = toUsdMinorUnits(amountRaw);
+    if (amountMinor < 0) {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "amount",
+        message: "amount must be non-negative."
+      });
+    }
+  } catch {
+    errors.push({
+      rowNumber,
+      code: "validation",
+      field: "amount",
+      message: "amount is invalid."
+    });
+  }
+
+  if (currencyRaw !== "USD") {
+    errors.push({
+      rowNumber,
+      code: "validation",
+      field: "currency",
+      message: "currency must be USD."
+    });
+  }
+
+  if (startDate && !isIsoDate(startDate)) {
+    errors.push({
+      rowNumber,
+      code: "validation",
+      field: "startDate",
+      message: "startDate must use YYYY-MM-DD format."
+    });
+  }
+  if (endDate && !isIsoDate(endDate)) {
+    errors.push({
+      rowNumber,
+      code: "validation",
+      field: "endDate",
+      message: "endDate must use YYYY-MM-DD format."
+    });
+  }
+
+  let recurrence: RecurrenceInput | undefined;
+  if (expenseType === "recurring") {
+    if (
+      frequencyRaw !== "monthly" &&
+      frequencyRaw !== "quarterly" &&
+      frequencyRaw !== "yearly"
+    ) {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "frequency",
+        message: "frequency is required for recurring expenses."
+      });
+    }
+
+    const interval = intervalRaw.length > 0 ? parseIntStrict(intervalRaw) : 1;
+    if (interval === null || interval <= 0) {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "interval",
+        message: "interval must be a positive integer."
+      });
+    }
+
+    const dayOfMonth = parseIntStrict(dayOfMonthRaw);
+    if (dayOfMonth === null || dayOfMonth < 1 || dayOfMonth > 31) {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "dayOfMonth",
+        message: "dayOfMonth must be an integer between 1 and 31."
+      });
+    }
+
+    const monthOfYear = monthOfYearRaw.length > 0 ? parseIntStrict(monthOfYearRaw) : null;
+    if (frequencyRaw === "yearly") {
+      if (monthOfYear === null || monthOfYear < 1 || monthOfYear > 12) {
+        errors.push({
+          rowNumber,
+          code: "validation",
+          field: "monthOfYear",
+          message: "monthOfYear is required for yearly recurrence."
+        });
+      }
+    } else if (monthOfYear !== null && (monthOfYear < 1 || monthOfYear > 12)) {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "monthOfYear",
+        message: "monthOfYear must be between 1 and 12."
+      });
+    }
+
+    if (anchorDate && !isIsoDate(anchorDate)) {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "anchorDate",
+        message: "anchorDate must use YYYY-MM-DD format."
+      });
+    }
+
+    if (
+      errors.length === 0 &&
+      interval !== null &&
+      dayOfMonth !== null &&
+      (frequencyRaw === "monthly" || frequencyRaw === "quarterly" || frequencyRaw === "yearly")
+    ) {
+      recurrence = {
+        frequency: frequencyRaw,
+        interval,
+        dayOfMonth,
+        monthOfYear: monthOfYear ?? undefined,
+        anchorDate: anchorDate || undefined
+      };
+    }
+  }
+
+  if (errors.length > 0 || !expenseType || !status) {
+    return { errors };
+  }
+
+  const baseRow: Omit<NormalizedImportRow, "fingerprint" | "rowNumber"> = {
+    scenarioId,
+    serviceId,
+    contractId: contractId || undefined,
+    name,
+    expenseType,
+    status,
+    amountMinor,
+    currency: "USD",
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+    recurrence
+  };
+
+  return {
+    value: {
+      rowNumber,
+      ...baseRow,
+      fingerprint: buildFingerprint(baseRow)
+    },
+    errors: []
+  };
+}
+
+function loadExistingFingerprints(db: Database.Database): Set<string> {
+  const rows = db
+    .prepare(
+      `
+        SELECT
+          e.scenario_id,
+          e.service_id,
+          e.contract_id,
+          e.name,
+          e.expense_type,
+          e.status,
+          e.amount_minor,
+          e.currency,
+          e.start_date,
+          e.end_date,
+          r.frequency,
+          r.interval,
+          r.day_of_month,
+          r.month_of_year,
+          r.anchor_date
+        FROM expense_line e
+        LEFT JOIN recurrence_rule r ON r.expense_line_id = e.id
+        WHERE e.deleted_at IS NULL
+      `
+    )
+    .all() as Array<{
+    scenario_id: string;
+    service_id: string;
+    contract_id: string | null;
+    name: string;
+    expense_type: ExpenseType;
+    status: ExpenseStatus;
+    amount_minor: number;
+    currency: string;
+    start_date: string | null;
+    end_date: string | null;
+    frequency: Frequency | null;
+    interval: number | null;
+    day_of_month: number | null;
+    month_of_year: number | null;
+    anchor_date: string | null;
+  }>;
+
+  const fingerprints = new Set<string>();
+  for (const row of rows) {
+    const recurrence: RecurrenceInput | undefined =
+      row.expense_type === "recurring" && row.frequency && row.interval && row.day_of_month
+        ? {
+            frequency: row.frequency,
+            interval: row.interval,
+            dayOfMonth: row.day_of_month,
+            monthOfYear: row.month_of_year ?? undefined,
+            anchorDate: row.anchor_date ?? undefined
+          }
+        : undefined;
+
+    fingerprints.add(
+      buildFingerprint({
+        scenarioId: row.scenario_id,
+        serviceId: row.service_id,
+        contractId: row.contract_id ?? undefined,
+        name: row.name,
+        expenseType: row.expense_type,
+        status: row.status,
+        amountMinor: row.amount_minor,
+        currency: "USD",
+        startDate: row.start_date ?? undefined,
+        endDate: row.end_date ?? undefined,
+        recurrence
+      })
+    );
+  }
+
+  return fingerprints;
+}
+
+function validateRows(
+  rows: Record<string, string>[],
+  mapping: ImportColumnMapping,
+  existingFingerprints: Set<string>
+): { acceptedRows: NormalizedImportRow[]; errors: ImportRowError[]; duplicateCount: number } {
+  const acceptedRows: NormalizedImportRow[] = [];
+  const errors: ImportRowError[] = [];
+  const seenFingerprints = new Set<string>();
+  let duplicateCount = 0;
+
+  for (let index = 0; index < rows.length; index += 1) {
+    const rowNumber = index + 2;
+    const normalized = normalizeRow(rows[index], rowNumber, mapping);
+    if (!normalized.value) {
+      errors.push(...normalized.errors);
+      continue;
+    }
+
+    if (existingFingerprints.has(normalized.value.fingerprint) || seenFingerprints.has(normalized.value.fingerprint)) {
+      duplicateCount += 1;
+      errors.push({
+        rowNumber,
+        code: "duplicate",
+        field: "row",
+        message: "Duplicate row skipped by deterministic fingerprint."
+      });
+      continue;
+    }
+
+    seenFingerprints.add(normalized.value.fingerprint);
+    acceptedRows.push(normalized.value);
+  }
+
+  return { acceptedRows, errors, duplicateCount };
+}
+
+export function previewExpenseImport(
+  db: Database.Database,
+  input: ImportPreviewInput
+): ImportPreviewResult {
+  const { headers, rows } = readImportRows(input.filePath);
+  const { mapping, templateApplied, templateSaved } = resolveMapping(headers, input);
+  const existingFingerprints = loadExistingFingerprints(db);
+  const { acceptedRows, errors, duplicateCount } = validateRows(rows, mapping, existingFingerprints);
+
+  return {
+    totalRows: rows.length,
+    acceptedCount: acceptedRows.length,
+    rejectedCount: errors.length,
+    duplicateCount,
+    mapping,
+    templateApplied,
+    templateSaved,
+    errors,
+    acceptedRows
+  };
+}
+
+export function commitExpenseImport(
+  db: Database.Database,
+  input: ImportPreviewInput
+): ImportCommitResult {
+  const preview = previewExpenseImport(db, input);
+  if (preview.acceptedRows.length === 0) {
+    return {
+      totalRows: preview.totalRows,
+      acceptedCount: preview.acceptedCount,
+      rejectedCount: preview.rejectedCount,
+      duplicateCount: preview.duplicateCount,
+      insertedCount: 0,
+      skippedDuplicateCount: preview.duplicateCount,
+      errors: preview.errors
+    };
+  }
+
+  const repo = new BudgetCrudRepository(db);
+  const write = db.transaction(() => {
+    for (const row of preview.acceptedRows) {
+      repo.createExpenseLineWithOptionalRecurrence(
+        {
+          scenarioId: row.scenarioId,
+          serviceId: row.serviceId,
+          contractId: row.contractId ?? null,
+          name: row.name,
+          expenseType: row.expenseType,
+          status: row.status,
+          amountMinor: row.amountMinor,
+          currency: "USD",
+          startDate: row.startDate,
+          endDate: row.endDate
+        },
+        row.recurrence
+          ? {
+              expenseLineId: "import-placeholder",
+              frequency: row.recurrence.frequency,
+              interval: row.recurrence.interval,
+              dayOfMonth: row.recurrence.dayOfMonth,
+              monthOfYear: row.recurrence.monthOfYear,
+              anchorDate: row.recurrence.anchorDate
+            }
+          : undefined
+      );
+    }
+  });
+  write();
+
+  return {
+    totalRows: preview.totalRows,
+    acceptedCount: preview.acceptedCount,
+    rejectedCount: preview.rejectedCount,
+    duplicateCount: preview.duplicateCount,
+    insertedCount: preview.acceptedRows.length,
+    skippedDuplicateCount: preview.duplicateCount,
+    errors: preview.errors
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
       "dependencies": {
         "@budgetit/core": "*",
         "@budgetit/db": "^0.1.0",
-        "electron": "^35.0.1"
+        "electron": "^35.0.1",
+        "xlsx": "^0.18.5"
       }
     },
     "apps/renderer": {
@@ -2304,6 +2305,14 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2925,6 +2934,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -3071,6 +3092,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3140,6 +3169,17 @@
       "optional": true,
       "dependencies": {
         "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/cross-dirname": {
@@ -4382,6 +4422,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -6449,6 +6497,17 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "optional": true
     },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ssri": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
@@ -7609,6 +7668,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7657,6 +7732,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",


### PR DESCRIPTION
## Summary
- add desktop import wizard service with CSV/XLSX parsing, column mapping, saved template reuse, row validation, and deterministic fingerprint dedupe
- wire import.preview and import.commit IPC handlers in desktop main process
- add renderer controls for preview/commit workflow and status/error display
- persist mapping templates between import sessions

## Tests
- 
pm --workspace @budgetit/desktop run lint
- 
pm --workspace @budgetit/desktop run typecheck
- 
pm --workspace @budgetit/desktop run test
- 
pm --workspace @budgetit/renderer run lint
- 
pm --workspace @budgetit/renderer run typecheck
- 
pm run lint
- 
pm run typecheck
- 
pm run test
- 
pm run build

Closes #24