### PR TITLE
feat: implement E2 auto-tagging rules and suggestions

### DIFF
--- a/apps/desktop/src/auto-tagging.test.ts
+++ b/apps/desktop/src/auto-tagging.test.ts
@@ -1,0 +1,238 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { bootstrapEncryptedDatabase, BudgetCrudRepository, runMigrations } from "@budgetit/db";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  applyAutoTagRules,
+  buildRuleFromSuggestion,
+  evaluateAutoTagRules,
+  recordManualTagCorrection,
+  suggestRulesFromManualCorrections,
+  type AutoTagRule
+} from "./auto-tagging";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-auto-tag-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+function seedEntities(repo: BudgetCrudRepository): {
+  vendorId: string;
+  serviceId: string;
+  dimensionId: string;
+  financeTagId: string;
+  engineeringTagId: string;
+} {
+  const vendorId = repo.createVendor({ name: "Contoso" });
+  const serviceId = repo.createService({
+    vendorId,
+    name: "Contoso SaaS",
+    status: "active"
+  });
+  const dimensionId = repo.createDimension({
+    name: "Cost Center",
+    mode: "single_select",
+    required: false
+  });
+  const financeTagId = repo.createTag({
+    dimensionId,
+    name: "Finance"
+  });
+  const engineeringTagId = repo.createTag({
+    dimensionId,
+    name: "Engineering"
+  });
+
+  return { vendorId, serviceId, dimensionId, financeTagId, engineeringTagId };
+}
+
+function createExpense(repo: BudgetCrudRepository, serviceId: string, name: string, amountMinor: number): string {
+  return repo.createExpenseLineWithOptionalRecurrence({
+    scenarioId: "baseline",
+    serviceId,
+    contractId: null,
+    name,
+    expenseType: "one_time",
+    status: "planned",
+    amountMinor,
+    currency: "USD"
+  });
+}
+
+describe("auto tagging", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("applies precedence when multiple rules match the same dimension", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const { vendorId, serviceId, dimensionId, financeTagId, engineeringTagId } = seedEntities(repo);
+      const expenseId = createExpense(repo, serviceId, "suite license", 12000);
+
+      const rules: AutoTagRule[] = [
+        {
+          id: "rule-generic",
+          name: "Generic Suite",
+          dimensionId,
+          tagId: financeTagId,
+          priority: 1,
+          enabled: true,
+          conditions: {
+            descriptionContains: "suite"
+          }
+        },
+        {
+          id: "rule-specific",
+          name: "Vendor-Specific Suite",
+          dimensionId,
+          tagId: engineeringTagId,
+          priority: 2,
+          enabled: true,
+          conditions: {
+            vendorId,
+            descriptionContains: "suite"
+          }
+        }
+      ];
+
+      const matches = evaluateAutoTagRules(rules, {
+        entityType: "expense_line",
+        entityId: expenseId,
+        vendorId,
+        description: "suite license",
+        amountMinor: 12000
+      });
+      expect(matches[0]?.ruleId).toBe("rule-specific");
+
+      applyAutoTagRules(boot.db, rules, {
+        entityType: "expense_line",
+        entityId: expenseId,
+        vendorId,
+        description: "suite license",
+        amountMinor: 12000
+      });
+
+      const assignment = boot.db
+        .prepare("SELECT tag_id FROM tag_assignment WHERE entity_type = 'expense_line' AND entity_id = ?")
+        .get(expenseId) as { tag_id: string } | undefined;
+      expect(assignment?.tag_id).toBe(engineeringTagId);
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("stores explainability text that maps to the applied rule", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const { vendorId, serviceId, dimensionId, financeTagId } = seedEntities(repo);
+      const expenseId = createExpense(repo, serviceId, "ops tooling", 3300);
+
+      const rules: AutoTagRule[] = [
+        {
+          id: "rule-explain",
+          name: "Ops Vendor Rule",
+          dimensionId,
+          tagId: financeTagId,
+          priority: 5,
+          enabled: true,
+          conditions: {
+            vendorId,
+            descriptionContains: "tooling",
+            amountMinMinor: 1000
+          }
+        }
+      ];
+
+      const applied = applyAutoTagRules(boot.db, rules, {
+        entityType: "expense_line",
+        entityId: expenseId,
+        vendorId,
+        description: "ops tooling",
+        amountMinor: 3300
+      });
+
+      expect(applied).toHaveLength(1);
+      expect(applied[0].explanation).toContain("Ops Vendor Rule");
+      expect(applied[0].explanation).toContain("vendorId=");
+      expect(applied[0].explanation).toContain("description contains");
+
+      const auditRow = boot.db
+        .prepare("SELECT after_json FROM audit_log WHERE action = 'tag_assignment.auto_rule_applied' LIMIT 1")
+        .get() as { after_json: string | null } | undefined;
+      expect(auditRow?.after_json).toContain("Ops Vendor Rule");
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("turns repeated manual corrections into a rule suggestion that reproduces tagging", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const { vendorId, serviceId, dimensionId, engineeringTagId } = seedEntities(repo);
+
+      for (let index = 0; index < 3; index += 1) {
+        recordManualTagCorrection(boot.db, {
+          entityType: "expense_line",
+          entityId: `manual-${index}`,
+          dimensionId,
+          fromTagId: null,
+          toTagId: engineeringTagId,
+          vendorId,
+          description: "suite license",
+          costCenter: "ENG",
+          amountMinor: 15000 + index
+        });
+      }
+
+      const suggestions = suggestRulesFromManualCorrections(boot.db, 3);
+      expect(suggestions).toHaveLength(1);
+      expect(suggestions[0].tagId).toBe(engineeringTagId);
+      expect(suggestions[0].conditions.vendorId).toBe(vendorId);
+      expect(suggestions[0].conditions.descriptionContains).toBe("suite license");
+
+      const acceptedRule = buildRuleFromSuggestion(suggestions[0], {
+        id: "rule-from-suggestion",
+        name: "Suggested Suite Rule",
+        priority: 3
+      });
+      const expenseId = createExpense(repo, serviceId, "suite license", 15001);
+      const applied = applyAutoTagRules(boot.db, [acceptedRule], {
+        entityType: "expense_line",
+        entityId: expenseId,
+        vendorId,
+        description: "suite license",
+        costCenter: "ENG",
+        amountMinor: 15001
+      });
+
+      expect(applied).toHaveLength(1);
+      expect(applied[0].tagId).toBe(engineeringTagId);
+      expect(applied[0].ruleId).toBe("rule-from-suggestion");
+
+      const assignment = boot.db
+        .prepare("SELECT tag_id FROM tag_assignment WHERE entity_type = 'expense_line' AND entity_id = ?")
+        .get(expenseId) as { tag_id: string } | undefined;
+      expect(assignment?.tag_id).toBe(engineeringTagId);
+    } finally {
+      boot.db.close();
+    }
+  });
+});

--- a/apps/desktop/src/auto-tagging.ts
+++ b/apps/desktop/src/auto-tagging.ts
@@ -1,0 +1,387 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { BudgetCrudRepository } from "@budgetit/db";
+import type Database from "better-sqlite3-multiple-ciphers";
+
+export type AutoTagRuleCondition = {
+  vendorId?: string;
+  descriptionContains?: string;
+  costCenter?: string;
+  amountMinMinor?: number;
+  amountMaxMinor?: number;
+};
+
+export type AutoTagRule = {
+  id: string;
+  name: string;
+  dimensionId: string;
+  tagId: string;
+  priority: number;
+  enabled: boolean;
+  conditions: AutoTagRuleCondition;
+};
+
+export type AutoTagCandidate = {
+  entityType: "expense_line";
+  entityId: string;
+  vendorId?: string;
+  description?: string;
+  costCenter?: string;
+  amountMinor: number;
+};
+
+export type AutoTagMatch = {
+  ruleId: string;
+  ruleName: string;
+  dimensionId: string;
+  tagId: string;
+  explanation: string;
+  score: number;
+};
+
+export type AutoTagSuggestion = {
+  dimensionId: string;
+  tagId: string;
+  evidenceCount: number;
+  conditions: AutoTagRuleCondition;
+};
+
+export type ManualTagCorrection = {
+  entityType: "expense_line";
+  entityId: string;
+  dimensionId: string;
+  fromTagId: string | null;
+  toTagId: string;
+  vendorId?: string;
+  description?: string;
+  costCenter?: string;
+  amountMinor: number;
+};
+
+type AutoTagRuleStore = {
+  rules: AutoTagRule[];
+};
+
+type StoredManualCorrection = {
+  dimensionId: string;
+  toTagId: string;
+  vendorId?: string;
+  description?: string;
+  costCenter?: string;
+  amountMinor: number;
+};
+
+function normalizeText(value: string | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function buildRuleExplanation(rule: AutoTagRule, reasons: string[]): string {
+  return `Rule ${rule.name} (${rule.id}) matched: ${reasons.join("; ")}`;
+}
+
+function evaluateRule(rule: AutoTagRule, candidate: AutoTagCandidate): AutoTagMatch | null {
+  if (!rule.enabled) {
+    return null;
+  }
+
+  const reasons: string[] = [];
+  let conditionCount = 0;
+  const conditions = rule.conditions;
+
+  if (conditions.vendorId) {
+    conditionCount += 1;
+    if (normalizeText(candidate.vendorId) !== normalizeText(conditions.vendorId)) {
+      return null;
+    }
+    reasons.push(`vendorId=${conditions.vendorId}`);
+  }
+
+  if (conditions.descriptionContains) {
+    conditionCount += 1;
+    const needle = normalizeText(conditions.descriptionContains);
+    if (!normalizeText(candidate.description).includes(needle)) {
+      return null;
+    }
+    reasons.push(`description contains "${conditions.descriptionContains}"`);
+  }
+
+  if (conditions.costCenter) {
+    conditionCount += 1;
+    if (normalizeText(candidate.costCenter) !== normalizeText(conditions.costCenter)) {
+      return null;
+    }
+    reasons.push(`costCenter=${conditions.costCenter}`);
+  }
+
+  if (typeof conditions.amountMinMinor === "number") {
+    conditionCount += 1;
+    if (candidate.amountMinor < conditions.amountMinMinor) {
+      return null;
+    }
+    reasons.push(`amount >= ${conditions.amountMinMinor}`);
+  }
+
+  if (typeof conditions.amountMaxMinor === "number") {
+    conditionCount += 1;
+    if (candidate.amountMinor > conditions.amountMaxMinor) {
+      return null;
+    }
+    reasons.push(`amount <= ${conditions.amountMaxMinor}`);
+  }
+
+  if (conditionCount === 0) {
+    return null;
+  }
+
+  return {
+    ruleId: rule.id,
+    ruleName: rule.name,
+    dimensionId: rule.dimensionId,
+    tagId: rule.tagId,
+    score: rule.priority * 100 + conditionCount,
+    explanation: buildRuleExplanation(rule, reasons)
+  };
+}
+
+function sortMatchesDescending(left: AutoTagMatch, right: AutoTagMatch): number {
+  if (left.score !== right.score) {
+    return right.score - left.score;
+  }
+  if (left.ruleName !== right.ruleName) {
+    return left.ruleName.localeCompare(right.ruleName);
+  }
+  return left.ruleId.localeCompare(right.ruleId);
+}
+
+export function evaluateAutoTagRules(
+  rules: AutoTagRule[],
+  candidate: AutoTagCandidate
+): AutoTagMatch[] {
+  const matches = rules
+    .map((rule) => evaluateRule(rule, candidate))
+    .filter((match): match is AutoTagMatch => match !== null)
+    .sort(sortMatchesDescending);
+
+  const chosenByDimension = new Set<string>();
+  const chosen: AutoTagMatch[] = [];
+  for (const match of matches) {
+    if (chosenByDimension.has(match.dimensionId)) {
+      continue;
+    }
+    chosenByDimension.add(match.dimensionId);
+    chosen.push(match);
+  }
+
+  return chosen;
+}
+
+export function applyAutoTagRules(
+  db: Database.Database,
+  rules: AutoTagRule[],
+  candidate: AutoTagCandidate
+): AutoTagMatch[] {
+  const selectedMatches = evaluateAutoTagRules(rules, candidate);
+  if (selectedMatches.length === 0) {
+    return [];
+  }
+
+  const repo = new BudgetCrudRepository(db);
+  const write = db.transaction(() => {
+    for (const match of selectedMatches) {
+      repo.assignTagToEntity({
+        entityType: candidate.entityType,
+        entityId: candidate.entityId,
+        dimensionId: match.dimensionId,
+        tagId: match.tagId
+      });
+
+      db.prepare(
+        `
+          INSERT INTO audit_log (
+            id,
+            actor,
+            action,
+            entity_type,
+            entity_id,
+            before_json,
+            after_json,
+            created_at
+          ) VALUES (?, 'system', 'tag_assignment.auto_rule_applied', ?, ?, NULL, ?, CURRENT_TIMESTAMP)
+        `
+      ).run(
+        crypto.randomUUID(),
+        candidate.entityType,
+        candidate.entityId,
+        JSON.stringify({
+          ruleId: match.ruleId,
+          ruleName: match.ruleName,
+          dimensionId: match.dimensionId,
+          tagId: match.tagId,
+          explanation: match.explanation
+        })
+      );
+    }
+  });
+  write();
+
+  return selectedMatches;
+}
+
+export function recordManualTagCorrection(
+  db: Database.Database,
+  correction: ManualTagCorrection
+): void {
+  const payload: StoredManualCorrection = {
+    dimensionId: correction.dimensionId,
+    toTagId: correction.toTagId,
+    vendorId: correction.vendorId,
+    description: correction.description,
+    costCenter: correction.costCenter,
+    amountMinor: correction.amountMinor
+  };
+
+  db.prepare(
+    `
+      INSERT INTO audit_log (
+        id,
+        actor,
+        action,
+        entity_type,
+        entity_id,
+        before_json,
+        after_json,
+        created_at
+      ) VALUES (?, 'user', 'tag_assignment.manual_correction', ?, ?, ?, ?, CURRENT_TIMESTAMP)
+    `
+  ).run(
+    crypto.randomUUID(),
+    correction.entityType,
+    correction.entityId,
+    JSON.stringify({ fromTagId: correction.fromTagId }),
+    JSON.stringify(payload)
+  );
+}
+
+export function suggestRulesFromManualCorrections(
+  db: Database.Database,
+  threshold = 3
+): AutoTagSuggestion[] {
+  const rows = db
+    .prepare(
+      `
+        SELECT after_json
+        FROM audit_log
+        WHERE action = 'tag_assignment.manual_correction'
+          AND entity_type = 'expense_line'
+      `
+    )
+    .all() as Array<{ after_json: string | null }>;
+
+  const parsed = rows
+    .map((row) => {
+      if (!row.after_json) {
+        return null;
+      }
+      try {
+        return JSON.parse(row.after_json) as StoredManualCorrection;
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry): entry is StoredManualCorrection => {
+      return (
+        entry !== null &&
+        typeof entry.dimensionId === "string" &&
+        typeof entry.toTagId === "string" &&
+        typeof entry.amountMinor === "number"
+      );
+    });
+
+  const grouped = new Map<string, StoredManualCorrection[]>();
+  for (const entry of parsed) {
+    const key = [
+      entry.dimensionId,
+      entry.toTagId,
+      normalizeText(entry.vendorId),
+      normalizeText(entry.description),
+      normalizeText(entry.costCenter)
+    ].join("|");
+    const bucket = grouped.get(key) ?? [];
+    bucket.push(entry);
+    grouped.set(key, bucket);
+  }
+
+  const suggestions: AutoTagSuggestion[] = [];
+  for (const corrections of grouped.values()) {
+    if (corrections.length < threshold) {
+      continue;
+    }
+
+    const first = corrections[0];
+    const amounts = corrections.map((entry) => entry.amountMinor);
+    suggestions.push({
+      dimensionId: first.dimensionId,
+      tagId: first.toTagId,
+      evidenceCount: corrections.length,
+      conditions: {
+        vendorId: first.vendorId,
+        descriptionContains: first.description,
+        costCenter: first.costCenter,
+        amountMinMinor: Math.min(...amounts),
+        amountMaxMinor: Math.max(...amounts)
+      }
+    });
+  }
+
+  return suggestions.sort((left, right) => right.evidenceCount - left.evidenceCount);
+}
+
+export function buildRuleFromSuggestion(
+  suggestion: AutoTagSuggestion,
+  input: { id: string; name: string; priority?: number; enabled?: boolean }
+): AutoTagRule {
+  return {
+    id: input.id,
+    name: input.name,
+    dimensionId: suggestion.dimensionId,
+    tagId: suggestion.tagId,
+    priority: input.priority ?? 1,
+    enabled: input.enabled ?? true,
+    conditions: suggestion.conditions
+  };
+}
+
+export function loadAutoTagRules(filePath: string): AutoTagRule[] {
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as Partial<AutoTagRuleStore>;
+  if (!Array.isArray(parsed.rules)) {
+    return [];
+  }
+
+  return parsed.rules.filter((rule): rule is AutoTagRule => {
+    return (
+      typeof rule?.id === "string" &&
+      typeof rule?.name === "string" &&
+      typeof rule?.dimensionId === "string" &&
+      typeof rule?.tagId === "string" &&
+      typeof rule?.priority === "number" &&
+      typeof rule?.enabled === "boolean" &&
+      typeof rule?.conditions === "object" &&
+      rule.conditions !== null
+    );
+  });
+}
+
+export function saveAutoTagRules(filePath: string, rules: AutoTagRule[]): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    `${JSON.stringify({ rules } satisfies AutoTagRuleStore, null, 2)}\n`,
+    "utf8"
+  );
+}


### PR DESCRIPTION
## Summary
- add auto-tag rules engine with precedence resolution for vendor/description/cost-center/amount conditions
- apply auto-tag rules during import commit and persist explainability in udit_log
- add manual correction recording and repeated-correction suggestion generation
- return suggestion payload from import.commit

## Tests
- 
pm --workspace @budgetit/desktop run lint
- 
pm --workspace @budgetit/desktop run typecheck
- 
pm --workspace @budgetit/desktop run test
- 
pm run lint
- 
pm run typecheck
- 
pm run test
- 
pm run build

Closes #25