### PR TITLE
feat: implement E3 actuals import and variance dataset

### DIFF
--- a/apps/desktop/src/actuals-import.ts
+++ b/apps/desktop/src/actuals-import.ts
@@ -1,0 +1,454 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  ingestActualTransactions,
+  listUnmatchedActualTransactions,
+  toUsdMinorUnits,
+  type ActualTransactionInput
+} from "@budgetit/db";
+import type Database from "better-sqlite3-multiple-ciphers";
+import * as XLSX from "xlsx";
+
+export type ActualImportField =
+  | "scenarioId"
+  | "serviceId"
+  | "contractId"
+  | "transactionDate"
+  | "amount"
+  | "currency"
+  | "description";
+
+export type ActualImportMapping = Partial<Record<ActualImportField, string>>;
+
+export type ActualImportError = {
+  rowNumber: number;
+  code: "validation" | "duplicate";
+  field: ActualImportField | "row";
+  message: string;
+};
+
+export type ActualImportPreviewInput = {
+  filePath: string;
+  mapping?: ActualImportMapping;
+};
+
+export type ActualImportPreviewResult = {
+  totalRows: number;
+  acceptedCount: number;
+  rejectedCount: number;
+  duplicateCount: number;
+  mapping: ActualImportMapping;
+  errors: ActualImportError[];
+  acceptedRows: ActualTransactionInput[];
+};
+
+export type ActualImportCommitResult = {
+  totalRows: number;
+  acceptedCount: number;
+  rejectedCount: number;
+  duplicateCount: number;
+  insertedCount: number;
+  matchedCount: number;
+  unmatchedCount: number;
+  matchRate: number;
+  errors: ActualImportError[];
+  unmatchedForReview: Array<{
+    id: string;
+    transactionDate: string;
+    amountMinor: number;
+    description: string | null;
+  }>;
+};
+
+const REQUIRED_FIELDS: ActualImportField[] = [
+  "scenarioId",
+  "serviceId",
+  "transactionDate",
+  "amount"
+];
+
+const FIELD_ALIASES: Record<ActualImportField, string[]> = {
+  scenarioId: ["scenario_id", "scenario", "scenarioid"],
+  serviceId: ["service_id", "service", "serviceid"],
+  contractId: ["contract_id", "contract", "contractid"],
+  transactionDate: ["transaction_date", "date", "posted_date"],
+  amount: ["amount", "amount_usd", "usd", "cost"],
+  currency: ["currency", "curr"],
+  description: ["description", "memo", "notes"]
+};
+
+function normalizeHeader(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, "_");
+}
+
+function parseCsvLine(line: string): string[] {
+  const values: string[] = [];
+  let current = "";
+  let insideQuotes = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index];
+    if (char === "\"") {
+      if (insideQuotes && line[index + 1] === "\"") {
+        current += "\"";
+        index += 1;
+      } else {
+        insideQuotes = !insideQuotes;
+      }
+      continue;
+    }
+    if (char === "," && !insideQuotes) {
+      values.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+
+  values.push(current);
+  return values.map((entry) => entry.trim());
+}
+
+function readCsvRows(filePath: string): { headers: string[]; rows: Record<string, string>[] } {
+  const lines = fs
+    .readFileSync(filePath, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return { headers: [], rows: [] };
+  }
+
+  const headers = parseCsvLine(lines[0]);
+  const rows = lines.slice(1).map((line) => {
+    const cells = parseCsvLine(line);
+    const record: Record<string, string> = {};
+    for (let index = 0; index < headers.length; index += 1) {
+      record[headers[index]] = cells[index] ?? "";
+    }
+    return record;
+  });
+  return { headers, rows };
+}
+
+function readXlsxRows(filePath: string): { headers: string[]; rows: Record<string, string>[] } {
+  const workbook = XLSX.readFile(filePath, { cellDates: false });
+  const sheetName = workbook.SheetNames[0];
+  if (!sheetName) {
+    return { headers: [], rows: [] };
+  }
+
+  const sheet = workbook.Sheets[sheetName];
+  const matrix = XLSX.utils.sheet_to_json<Array<string | number | boolean | null>>(sheet, {
+    header: 1,
+    defval: ""
+  });
+  if (matrix.length === 0) {
+    return { headers: [], rows: [] };
+  }
+
+  const headers = matrix[0].map((value) => String(value ?? "").trim());
+  const rows = matrix.slice(1).map((line) => {
+    const record: Record<string, string> = {};
+    for (let index = 0; index < headers.length; index += 1) {
+      record[headers[index]] = String(line[index] ?? "").trim();
+    }
+    return record;
+  });
+
+  return { headers, rows };
+}
+
+function readRows(filePath: string): { headers: string[]; rows: Record<string, string>[] } {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === ".csv") {
+    return readCsvRows(filePath);
+  }
+  if (extension === ".xlsx") {
+    return readXlsxRows(filePath);
+  }
+  throw new Error("Unsupported import file type. Use .csv or .xlsx.");
+}
+
+function autoMapping(headers: string[]): ActualImportMapping {
+  const byNormalized = new Map<string, string>();
+  for (const header of headers) {
+    byNormalized.set(normalizeHeader(header), header);
+  }
+
+  const mapping: ActualImportMapping = {};
+  const fields = Object.keys(FIELD_ALIASES) as ActualImportField[];
+  for (const field of fields) {
+    for (const alias of FIELD_ALIASES[field]) {
+      const header = byNormalized.get(alias);
+      if (header) {
+        mapping[field] = header;
+        break;
+      }
+    }
+  }
+  return mapping;
+}
+
+function normalizeMapping(headers: string[], mapping: ActualImportMapping | undefined): ActualImportMapping {
+  if (!mapping) {
+    return autoMapping(headers);
+  }
+
+  const availableHeaders = new Set(headers);
+  const normalized: ActualImportMapping = {};
+  const fields = Object.keys(mapping) as ActualImportField[];
+  for (const field of fields) {
+    const header = mapping[field];
+    if (header && availableHeaders.has(header)) {
+      normalized[field] = header;
+    }
+  }
+  return normalized;
+}
+
+function isIsoDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  return !Number.isNaN(new Date(`${value}T00:00:00.000Z`).getTime());
+}
+
+function valueAt(row: Record<string, string>, mapping: ActualImportMapping, field: ActualImportField): string {
+  const column = mapping[field];
+  if (!column) {
+    return "";
+  }
+  return (row[column] ?? "").trim();
+}
+
+function fingerprint(row: ActualTransactionInput): string {
+  return crypto
+    .createHash("sha256")
+    .update(
+      [
+        row.scenarioId,
+        row.serviceId,
+        row.contractId ?? "",
+        row.transactionDate,
+        row.amountMinor,
+        row.currency,
+        row.description ?? ""
+      ].join("|")
+    )
+    .digest("hex");
+}
+
+function loadExistingFingerprints(db: Database.Database): Set<string> {
+  const rows = db
+    .prepare(
+      `
+        SELECT
+          scenario_id,
+          service_id,
+          contract_id,
+          transaction_date,
+          amount_minor,
+          currency,
+          description
+        FROM spend_transaction
+      `
+    )
+    .all() as Array<{
+    scenario_id: string;
+    service_id: string;
+    contract_id: string | null;
+    transaction_date: string;
+    amount_minor: number;
+    currency: string;
+    description: string | null;
+  }>;
+
+  const result = new Set<string>();
+  for (const row of rows) {
+    result.add(
+      fingerprint({
+        scenarioId: row.scenario_id,
+        serviceId: row.service_id,
+        contractId: row.contract_id,
+        transactionDate: row.transaction_date,
+        amountMinor: row.amount_minor,
+        currency: "USD",
+        description: row.description ?? undefined
+      })
+    );
+  }
+  return result;
+}
+
+function validateRows(
+  rows: Record<string, string>[],
+  mapping: ActualImportMapping,
+  existingFingerprints: Set<string>
+): { acceptedRows: ActualTransactionInput[]; errors: ActualImportError[]; duplicateCount: number } {
+  const errors: ActualImportError[] = [];
+  const acceptedRows: ActualTransactionInput[] = [];
+  const seenFingerprints = new Set<string>();
+  let duplicateCount = 0;
+
+  for (let index = 0; index < rows.length; index += 1) {
+    const rowNumber = index + 2;
+
+    for (const field of REQUIRED_FIELDS) {
+      if (!mapping[field]) {
+        errors.push({
+          rowNumber,
+          code: "validation",
+          field,
+          message: `Missing mapping for required field: ${field}`
+        });
+      }
+    }
+
+    const scenarioId = valueAt(rows[index], mapping, "scenarioId");
+    const serviceId = valueAt(rows[index], mapping, "serviceId");
+    const contractId = valueAt(rows[index], mapping, "contractId");
+    const transactionDate = valueAt(rows[index], mapping, "transactionDate");
+    const amountRaw = valueAt(rows[index], mapping, "amount");
+    const currency = valueAt(rows[index], mapping, "currency").toUpperCase() || "USD";
+    const description = valueAt(rows[index], mapping, "description");
+
+    if (!scenarioId) {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "scenarioId",
+        message: "scenarioId is required."
+      });
+    }
+    if (!serviceId) {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "serviceId",
+        message: "serviceId is required."
+      });
+    }
+    if (!isIsoDate(transactionDate)) {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "transactionDate",
+        message: "transactionDate must use YYYY-MM-DD format."
+      });
+    }
+    if (currency !== "USD") {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "currency",
+        message: "currency must be USD."
+      });
+    }
+
+    let amountMinor = 0;
+    try {
+      amountMinor = toUsdMinorUnits(amountRaw);
+      if (amountMinor < 0) {
+        errors.push({
+          rowNumber,
+          code: "validation",
+          field: "amount",
+          message: "amount must be non-negative."
+        });
+      }
+    } catch {
+      errors.push({
+        rowNumber,
+        code: "validation",
+        field: "amount",
+        message: "amount is invalid."
+      });
+    }
+
+    const latestErrorIndex = errors.findIndex((entry) => entry.rowNumber === rowNumber);
+    if (latestErrorIndex >= 0) {
+      continue;
+    }
+
+    const normalized: ActualTransactionInput = {
+      scenarioId,
+      serviceId,
+      contractId: contractId || undefined,
+      transactionDate,
+      amountMinor,
+      currency: "USD",
+      description: description || undefined
+    };
+
+    const rowFingerprint = fingerprint(normalized);
+    if (seenFingerprints.has(rowFingerprint) || existingFingerprints.has(rowFingerprint)) {
+      duplicateCount += 1;
+      errors.push({
+        rowNumber,
+        code: "duplicate",
+        field: "row",
+        message: "Duplicate actual transaction row skipped."
+      });
+      continue;
+    }
+
+    seenFingerprints.add(rowFingerprint);
+    acceptedRows.push(normalized);
+  }
+
+  return { acceptedRows, errors, duplicateCount };
+}
+
+export function previewActualsImport(
+  db: Database.Database,
+  input: ActualImportPreviewInput
+): ActualImportPreviewResult {
+  const { headers, rows } = readRows(input.filePath);
+  const mapping = normalizeMapping(headers, input.mapping);
+  const existingFingerprints = loadExistingFingerprints(db);
+  const { acceptedRows, errors, duplicateCount } = validateRows(rows, mapping, existingFingerprints);
+
+  return {
+    totalRows: rows.length,
+    acceptedCount: acceptedRows.length,
+    rejectedCount: errors.length,
+    duplicateCount,
+    mapping,
+    errors,
+    acceptedRows
+  };
+}
+
+export function commitActualsImport(
+  db: Database.Database,
+  input: ActualImportPreviewInput
+): ActualImportCommitResult {
+  const preview = previewActualsImport(db, input);
+  const ingestResult = ingestActualTransactions(db, preview.acceptedRows);
+  const scenarioId = preview.acceptedRows[0]?.scenarioId;
+  const unmatchedForReview = scenarioId
+    ? listUnmatchedActualTransactions(db, scenarioId).slice(0, 20).map((entry) => ({
+        id: entry.id,
+        transactionDate: entry.transactionDate,
+        amountMinor: entry.amountMinor,
+        description: entry.description
+      }))
+    : [];
+
+  return {
+    totalRows: preview.totalRows,
+    acceptedCount: preview.acceptedCount,
+    rejectedCount: preview.rejectedCount,
+    duplicateCount: preview.duplicateCount,
+    insertedCount: ingestResult.inserted,
+    matchedCount: ingestResult.matched,
+    unmatchedCount: ingestResult.unmatched,
+    matchRate: ingestResult.matchRate,
+    errors: preview.errors,
+    unmatchedForReview
+  };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -37,5 +37,14 @@ export {
   type AlertEventRecord,
   type AlertEventStatus
 } from "./alerts-repository";
+export {
+  buildMonthlyVarianceDataset,
+  ingestActualTransactions,
+  listUnmatchedActualTransactions,
+  type ActualIngestResult,
+  type ActualTransactionInput,
+  type MonthlyVarianceRow,
+  type UnmatchedActualTransaction
+} from "./variance";
 export * as schema from "./schema";
 

--- a/packages/db/src/variance.test.ts
+++ b/packages/db/src/variance.test.ts
@@ -1,0 +1,259 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { bootstrapEncryptedDatabase } from "./encrypted-db";
+import { materializeScenarioOccurrences } from "./forecast-engine";
+import { runMigrations } from "./migrations";
+import { BudgetCrudRepository } from "./repositories";
+import {
+  buildMonthlyVarianceDataset,
+  ingestActualTransactions,
+  listUnmatchedActualTransactions
+} from "./variance";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-variance-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("actuals import and variance dataset", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("matches actual transactions to forecast occurrences with expected match rate", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const vendorId = repo.createVendor({ name: "Vendor" });
+      const serviceId = repo.createService({ vendorId, name: "Service", status: "active" });
+
+      repo.createExpenseLineWithOptionalRecurrence(
+        {
+          scenarioId: "baseline",
+          serviceId,
+          name: "Subscription",
+          expenseType: "recurring",
+          status: "planned",
+          amountMinor: 10000,
+          currency: "USD",
+          startDate: "2026-01-01"
+        },
+        {
+          expenseLineId: "ignored",
+          frequency: "monthly",
+          interval: 1,
+          dayOfMonth: 1,
+          anchorDate: "2026-01-01"
+        }
+      );
+      materializeScenarioOccurrences(boot.db, "baseline", 2);
+
+      const result = ingestActualTransactions(boot.db, [
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-01-01",
+          amountMinor: 10000,
+          currency: "USD",
+          description: "January invoice"
+        },
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-02-01",
+          amountMinor: 12000,
+          currency: "USD",
+          description: "February overage"
+        },
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-03-01",
+          amountMinor: 10000,
+          currency: "USD",
+          description: "March invoice"
+        }
+      ]);
+
+      expect(result.inserted).toBe(3);
+      expect(result.matched).toBe(2);
+      expect(result.unmatched).toBe(1);
+      expect(result.matchRate).toBeCloseTo(2 / 3, 4);
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("surfaces unmatched actuals for review", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const vendorId = repo.createVendor({ name: "Vendor" });
+      const serviceId = repo.createService({ vendorId, name: "Service", status: "active" });
+
+      repo.createExpenseLineWithOptionalRecurrence(
+        {
+          scenarioId: "baseline",
+          serviceId,
+          name: "Subscription",
+          expenseType: "recurring",
+          status: "planned",
+          amountMinor: 10000,
+          currency: "USD",
+          startDate: "2026-01-01"
+        },
+        {
+          expenseLineId: "ignored",
+          frequency: "monthly",
+          interval: 1,
+          dayOfMonth: 1,
+          anchorDate: "2026-01-01"
+        }
+      );
+      materializeScenarioOccurrences(boot.db, "baseline", 1);
+
+      ingestActualTransactions(boot.db, [
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-01-01",
+          amountMinor: 10000,
+          currency: "USD",
+          description: "Matched"
+        },
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-02-01",
+          amountMinor: 13000,
+          currency: "USD",
+          description: "Unmatched"
+        }
+      ]);
+
+      const unmatched = listUnmatchedActualTransactions(boot.db, "baseline");
+      expect(unmatched).toHaveLength(1);
+      expect(unmatched[0].description).toBe("Unmatched");
+      expect(unmatched[0].amountMinor).toBe(13000);
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("computes monthly variance totals that match hand-calculated expectations", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const vendorId = repo.createVendor({ name: "Vendor" });
+      const serviceId = repo.createService({ vendorId, name: "Service", status: "active" });
+
+      repo.createExpenseLineWithOptionalRecurrence(
+        {
+          scenarioId: "baseline",
+          serviceId,
+          name: "Subscription",
+          expenseType: "recurring",
+          status: "planned",
+          amountMinor: 10000,
+          currency: "USD",
+          startDate: "2026-01-01"
+        },
+        {
+          expenseLineId: "ignored",
+          frequency: "monthly",
+          interval: 1,
+          dayOfMonth: 1,
+          anchorDate: "2026-01-01"
+        }
+      );
+      materializeScenarioOccurrences(boot.db, "baseline", 2);
+
+      ingestActualTransactions(boot.db, [
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-01-01",
+          amountMinor: 10000,
+          currency: "USD",
+          description: "January invoice"
+        },
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-02-01",
+          amountMinor: 12000,
+          currency: "USD",
+          description: "February overage"
+        },
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-03-01",
+          amountMinor: 10000,
+          currency: "USD",
+          description: "March invoice"
+        }
+      ]);
+
+      const variance = buildMonthlyVarianceDataset(boot.db, "baseline");
+      expect(variance).toEqual([
+        {
+          month: "2026-01",
+          forecastMinor: 10000,
+          actualMinor: 10000,
+          varianceMinor: 0,
+          unmatchedActualMinor: 0,
+          unmatchedCount: 0
+        },
+        {
+          month: "2026-02",
+          forecastMinor: 10000,
+          actualMinor: 12000,
+          varianceMinor: 2000,
+          unmatchedActualMinor: 12000,
+          unmatchedCount: 1
+        },
+        {
+          month: "2026-03",
+          forecastMinor: 10000,
+          actualMinor: 10000,
+          varianceMinor: 0,
+          unmatchedActualMinor: 0,
+          unmatchedCount: 0
+        }
+      ]);
+
+      const totals = variance.reduce(
+        (acc, row) => {
+          acc.forecast += row.forecastMinor;
+          acc.actual += row.actualMinor;
+          acc.variance += row.varianceMinor;
+          return acc;
+        },
+        { forecast: 0, actual: 0, variance: 0 }
+      );
+      expect(totals).toEqual({
+        forecast: 30000,
+        actual: 32000,
+        variance: 2000
+      });
+    } finally {
+      boot.db.close();
+    }
+  });
+});

--- a/packages/db/src/variance.ts
+++ b/packages/db/src/variance.ts
@@ -1,0 +1,256 @@
+import crypto from "node:crypto";
+
+import type Database from "better-sqlite3-multiple-ciphers";
+
+export type ActualTransactionInput = {
+  scenarioId: string;
+  serviceId: string;
+  contractId?: string | null;
+  transactionDate: string;
+  amountMinor: number;
+  currency: "USD";
+  description?: string;
+};
+
+export type ActualIngestResult = {
+  inserted: number;
+  matched: number;
+  unmatched: number;
+  matchRate: number;
+};
+
+export type UnmatchedActualTransaction = {
+  id: string;
+  scenarioId: string;
+  serviceId: string;
+  contractId: string | null;
+  transactionDate: string;
+  amountMinor: number;
+  currency: "USD";
+  description: string | null;
+};
+
+export type MonthlyVarianceRow = {
+  month: string;
+  forecastMinor: number;
+  actualMinor: number;
+  varianceMinor: number;
+  unmatchedActualMinor: number;
+  unmatchedCount: number;
+};
+
+function isIsoDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime());
+}
+
+function assertTransactionInput(input: ActualTransactionInput): void {
+  if (!input.scenarioId) {
+    throw new Error("scenarioId is required.");
+  }
+  if (!input.serviceId) {
+    throw new Error("serviceId is required.");
+  }
+  if (!isIsoDate(input.transactionDate)) {
+    throw new Error("transactionDate must use YYYY-MM-DD format.");
+  }
+  if (!Number.isInteger(input.amountMinor) || input.amountMinor < 0) {
+    throw new Error("amountMinor must be a non-negative integer.");
+  }
+}
+
+function findMatchCandidates(
+  db: Database.Database,
+  input: ActualTransactionInput
+): Array<{ id: string }> {
+  return db
+    .prepare(
+      `
+        SELECT o.id
+        FROM occurrence o
+        JOIN expense_line e ON e.id = o.expense_line_id
+        LEFT JOIN spend_transaction t ON t.matched_occurrence_id = o.id
+        WHERE o.scenario_id = ?
+          AND e.service_id = ?
+          AND o.amount_minor = ?
+          AND o.currency = ?
+          AND t.id IS NULL
+          AND substr(o.occurrence_date, 1, 7) = substr(?, 1, 7)
+        ORDER BY ABS(julianday(o.occurrence_date) - julianday(?)), o.occurrence_date
+        LIMIT 24
+      `
+    )
+    .all(
+      input.scenarioId,
+      input.serviceId,
+      input.amountMinor,
+      input.currency,
+      input.transactionDate,
+      input.transactionDate
+    ) as Array<{ id: string }>;
+}
+
+export function ingestActualTransactions(
+  db: Database.Database,
+  inputs: ActualTransactionInput[]
+): ActualIngestResult {
+  let inserted = 0;
+  let matched = 0;
+  let unmatched = 0;
+  const usedOccurrenceIds = new Set<string>();
+
+  const write = db.transaction(() => {
+    for (const input of inputs) {
+      assertTransactionInput(input);
+      const candidates = findMatchCandidates(db, input);
+      const selected = candidates.find((entry) => !usedOccurrenceIds.has(entry.id));
+      const matchedOccurrenceId = selected?.id ?? null;
+      if (matchedOccurrenceId) {
+        usedOccurrenceIds.add(matchedOccurrenceId);
+      }
+
+      db.prepare(
+        `
+          INSERT INTO spend_transaction (
+            id,
+            scenario_id,
+            service_id,
+            contract_id,
+            transaction_date,
+            amount_minor,
+            currency,
+            description,
+            matched_occurrence_id,
+            created_at,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        `
+      ).run(
+        crypto.randomUUID(),
+        input.scenarioId,
+        input.serviceId,
+        input.contractId ?? null,
+        input.transactionDate,
+        input.amountMinor,
+        input.currency,
+        input.description ?? null,
+        matchedOccurrenceId
+      );
+
+      if (matchedOccurrenceId) {
+        db.prepare(
+          "UPDATE occurrence SET state = 'actualized', updated_at = CURRENT_TIMESTAMP WHERE id = ?"
+        ).run(matchedOccurrenceId);
+        matched += 1;
+      } else {
+        unmatched += 1;
+      }
+
+      inserted += 1;
+    }
+  });
+  write();
+
+  return {
+    inserted,
+    matched,
+    unmatched,
+    matchRate: inserted === 0 ? 0 : matched / inserted
+  };
+}
+
+export function listUnmatchedActualTransactions(
+  db: Database.Database,
+  scenarioId: string
+): UnmatchedActualTransaction[] {
+  return db
+    .prepare(
+      `
+        SELECT
+          id,
+          scenario_id AS scenarioId,
+          service_id AS serviceId,
+          contract_id AS contractId,
+          transaction_date AS transactionDate,
+          amount_minor AS amountMinor,
+          currency,
+          description
+        FROM spend_transaction
+        WHERE scenario_id = ?
+          AND matched_occurrence_id IS NULL
+        ORDER BY transaction_date ASC, created_at ASC
+      `
+    )
+    .all(scenarioId) as UnmatchedActualTransaction[];
+}
+
+export function buildMonthlyVarianceDataset(
+  db: Database.Database,
+  scenarioId: string
+): MonthlyVarianceRow[] {
+  const forecastRows = db
+    .prepare(
+      `
+        SELECT
+          substr(occurrence_date, 1, 7) AS month,
+          SUM(amount_minor) AS forecast_minor
+        FROM occurrence
+        WHERE scenario_id = ?
+        GROUP BY month
+      `
+    )
+    .all(scenarioId) as Array<{ month: string; forecast_minor: number }>;
+
+  const actualRows = db
+    .prepare(
+      `
+        SELECT
+          substr(transaction_date, 1, 7) AS month,
+          SUM(amount_minor) AS actual_minor,
+          SUM(CASE WHEN matched_occurrence_id IS NULL THEN amount_minor ELSE 0 END) AS unmatched_actual_minor,
+          SUM(CASE WHEN matched_occurrence_id IS NULL THEN 1 ELSE 0 END) AS unmatched_count
+        FROM spend_transaction
+        WHERE scenario_id = ?
+        GROUP BY month
+      `
+    )
+    .all(scenarioId) as Array<{
+    month: string;
+    actual_minor: number;
+    unmatched_actual_minor: number;
+    unmatched_count: number;
+  }>;
+
+  const rowsByMonth = new Map<string, MonthlyVarianceRow>();
+  for (const row of forecastRows) {
+    rowsByMonth.set(row.month, {
+      month: row.month,
+      forecastMinor: row.forecast_minor,
+      actualMinor: 0,
+      varianceMinor: -row.forecast_minor,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    });
+  }
+
+  for (const row of actualRows) {
+    const existing = rowsByMonth.get(row.month) ?? {
+      month: row.month,
+      forecastMinor: 0,
+      actualMinor: 0,
+      varianceMinor: 0,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    };
+    existing.actualMinor = row.actual_minor;
+    existing.unmatchedActualMinor = row.unmatched_actual_minor;
+    existing.unmatchedCount = row.unmatched_count;
+    existing.varianceMinor = existing.actualMinor - existing.forecastMinor;
+    rowsByMonth.set(row.month, existing);
+  }
+
+  return Array.from(rowsByMonth.values()).sort((left, right) => left.month.localeCompare(right.month));
+}


### PR DESCRIPTION
## Summary
- add DB actuals pipeline: transaction ingest, deterministic occurrence matching, unmatched listing, and monthly variance dataset builder
- add fixture tests covering match-rate expectations, unmatched review workflow, and variance totals
- add desktop actuals import mode in import.preview/import.commit
- add eports.query support for ariance.monthly
- update renderer import UI to support actuals mode and display matching metrics

## Tests
- 
pm --workspace @budgetit/db run lint
- 
pm --workspace @budgetit/db run typecheck
- 
pm --workspace @budgetit/db run test
- 
pm --workspace @budgetit/desktop run lint
- 
pm --workspace @budgetit/db run build && npm --workspace @budgetit/desktop run typecheck
- 
pm run lint
- 
pm run typecheck
- 
pm run test
- 
pm run build

Closes #26