### PR TITLE
feat: implement E4 replacement planning and attachment security

### DIFF
--- a/apps/desktop/src/attachment-store.test.ts
+++ b/apps/desktop/src/attachment-store.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createAttachmentStore } from "./attachment-store";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-attachment-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("attachment store", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("denies attachment reads without an active DB key context", () => {
+    const baseDir = createTempDir();
+    let activeDbKeyHex: string | null = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const store = createAttachmentStore(baseDir, () => activeDbKeyHex);
+
+    const content = Buffer.from("replacement scorecard attachment");
+    const written = store.writeAttachment({
+      entityType: "service_plan",
+      entityId: "plan-1",
+      fileName: "scorecard.txt",
+      content
+    });
+
+    activeDbKeyHex = null;
+    expect(() => store.readAttachment(written.filePath)).toThrow(
+      /Attachment access denied without active DB key context/
+    );
+
+    activeDbKeyHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const decrypted = store.readAttachment(written.filePath);
+    expect(decrypted.equals(content)).toBe(true);
+  });
+});

--- a/apps/desktop/src/attachment-store.ts
+++ b/apps/desktop/src/attachment-store.ts
@@ -1,0 +1,92 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+const FILE_MAGIC = Buffer.from("BATT1");
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+export type AttachmentStore = {
+  writeAttachment: (input: {
+    entityType: string;
+    entityId: string;
+    fileName: string;
+    content: Buffer;
+  }) => {
+    filePath: string;
+    contentSha256: string;
+  };
+  readAttachment: (filePath: string) => Buffer;
+};
+
+function resolveCipherKey(keyHex: string | null): Buffer {
+  if (!keyHex) {
+    throw new Error("Attachment access denied without active DB key context.");
+  }
+  const key = Buffer.from(keyHex, "hex");
+  if (key.length < 32) {
+    throw new Error("Attachment access denied without active DB key context.");
+  }
+  return key.subarray(0, 32);
+}
+
+function encryptWithKey(content: Buffer, key: Buffer): Buffer {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(content), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([FILE_MAGIC, iv, tag, encrypted]);
+}
+
+function decryptWithKey(payload: Buffer, key: Buffer): Buffer {
+  if (payload.length < FILE_MAGIC.length + IV_LENGTH + AUTH_TAG_LENGTH) {
+    throw new Error("Attachment payload is invalid.");
+  }
+  if (!payload.subarray(0, FILE_MAGIC.length).equals(FILE_MAGIC)) {
+    throw new Error("Attachment payload is invalid.");
+  }
+
+  const ivStart = FILE_MAGIC.length;
+  const tagStart = ivStart + IV_LENGTH;
+  const contentStart = tagStart + AUTH_TAG_LENGTH;
+  const iv = payload.subarray(ivStart, tagStart);
+  const tag = payload.subarray(tagStart, contentStart);
+  const encrypted = payload.subarray(contentStart);
+
+  const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]);
+}
+
+function sanitizeFileName(value: string): string {
+  return value.replace(/[^\w.-]/g, "_");
+}
+
+export function createAttachmentStore(
+  baseDir: string,
+  getActiveDbKeyHex: () => string | null
+): AttachmentStore {
+  return {
+    writeAttachment: (input) => {
+      const key = resolveCipherKey(getActiveDbKeyHex());
+      const encrypted = encryptWithKey(input.content, key);
+      const contentSha256 = crypto.createHash("sha256").update(input.content).digest("hex");
+
+      const entityDir = path.join(baseDir, input.entityType, input.entityId);
+      fs.mkdirSync(entityDir, { recursive: true });
+      const safeName = sanitizeFileName(input.fileName);
+      const filePath = path.join(entityDir, `${crypto.randomUUID()}-${safeName}.enc`);
+      fs.writeFileSync(filePath, encrypted);
+
+      return {
+        filePath,
+        contentSha256
+      };
+    },
+    readAttachment: (filePath) => {
+      const key = resolveCipherKey(getActiveDbKeyHex());
+      const payload = fs.readFileSync(filePath);
+      return decryptWithKey(payload, key);
+    }
+  };
+}

--- a/packages/db/migrations/008_replacement_scorecards.sql
+++ b/packages/db/migrations/008_replacement_scorecards.sql
@@ -1,0 +1,6 @@
+ALTER TABLE replacement_candidate
+ADD COLUMN scorecard_json TEXT;
+
+UPDATE meta
+SET schema_version = 8,
+    updated_at = CURRENT_TIMESTAMP;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -46,5 +46,21 @@ export {
   type MonthlyVarianceRow,
   type UnmatchedActualTransaction
 } from "./variance";
+export {
+  computeWeightedScore,
+  createAttachmentReference,
+  createServicePlan,
+  getReplacementPlanDetail,
+  listAttachmentReferences,
+  setReplacementSelection,
+  transitionServicePlan,
+  upsertReplacementCandidate,
+  type ReplacementCandidateDetail,
+  type ReplacementPlanDetail,
+  type ReplacementScorecardInput,
+  type ServicePlanAction,
+  type ServicePlanDecisionStatus,
+  type ServicePlanReasonCode
+} from "./replacement-planning";
 export * as schema from "./schema";
 

--- a/packages/db/src/migrations.test.ts
+++ b/packages/db/src/migrations.test.ts
@@ -39,13 +39,14 @@ describe("migration runner", () => {
         "004_forecast_state.sql",
         "005_scenarios.sql",
         "006_alert_dedupe.sql",
-        "007_alert_snooze.sql"
+        "007_alert_snooze.sql",
+        "008_replacement_scorecards.sql"
       ]);
 
       const metaRow = boot.db
         .prepare("SELECT schema_version, last_mutation_at, forecast_stale FROM meta WHERE id = 1")
         .get() as { schema_version: number; last_mutation_at: string; forecast_stale: number };
-      expect(metaRow.schema_version).toBe(7);
+      expect(metaRow.schema_version).toBe(8);
       expect(metaRow.forecast_stale).toBe(1);
       expect(metaRow.last_mutation_at.length).toBeGreaterThan(0);
     } finally {
@@ -81,7 +82,8 @@ describe("migration runner", () => {
         "004_forecast_state.sql",
         "005_scenarios.sql",
         "006_alert_dedupe.sql",
-        "007_alert_snooze.sql"
+        "007_alert_snooze.sql",
+        "008_replacement_scorecards.sql"
       ]);
 
       const indexRow = boot.db

--- a/packages/db/src/replacement-planning.test.ts
+++ b/packages/db/src/replacement-planning.test.ts
@@ -1,0 +1,166 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { bootstrapEncryptedDatabase } from "./encrypted-db";
+import { runMigrations } from "./migrations";
+import {
+  createAttachmentReference,
+  createServicePlan,
+  getReplacementPlanDetail,
+  listAttachmentReferences,
+  setReplacementSelection,
+  transitionServicePlan,
+  upsertReplacementCandidate
+} from "./replacement-planning";
+import { BudgetCrudRepository } from "./repositories";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-replacement-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("replacement planning workflows", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("enforces required fields during workflow transitions", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const vendorId = repo.createVendor({ name: "Vendor" });
+      const currentServiceId = repo.createService({
+        vendorId,
+        name: "Current Service",
+        status: "active"
+      });
+      const replacementServiceId = repo.createService({
+        vendorId,
+        name: "Replacement Service",
+        status: "active"
+      });
+
+      const servicePlanId = createServicePlan(boot.db, {
+        scenarioId: "baseline",
+        serviceId: currentServiceId,
+        plannedAction: "replace",
+        replacementRequired: true
+      });
+
+      transitionServicePlan(boot.db, {
+        servicePlanId,
+        nextStatus: "reviewed"
+      });
+
+      expect(() =>
+        transitionServicePlan(boot.db, {
+          servicePlanId,
+          nextStatus: "approved"
+        })
+      ).toThrow(/reasonCode is required/);
+
+      expect(() =>
+        transitionServicePlan(boot.db, {
+          servicePlanId,
+          nextStatus: "approved",
+          reasonCode: "eol"
+        })
+      ).toThrow(/replacementSelectedServiceId is required/);
+
+      setReplacementSelection(boot.db, {
+        servicePlanId,
+        replacementSelectedServiceId: replacementServiceId
+      });
+
+      transitionServicePlan(boot.db, {
+        servicePlanId,
+        nextStatus: "approved",
+        reasonCode: "eol"
+      });
+
+      const row = boot.db
+        .prepare("SELECT decision_status, reason_code FROM service_plan WHERE id = ?")
+        .get(servicePlanId) as { decision_status: string; reason_code: string | null };
+      expect(row.decision_status).toBe("approved");
+      expect(row.reason_code).toBe("eol");
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("returns replacement candidate score aggregation in plan detail", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const vendorId = repo.createVendor({ name: "Vendor" });
+      const currentServiceId = repo.createService({
+        vendorId,
+        name: "Current Service",
+        status: "active"
+      });
+
+      const servicePlanId = createServicePlan(boot.db, {
+        scenarioId: "baseline",
+        serviceId: currentServiceId,
+        plannedAction: "replace",
+        replacementRequired: true
+      });
+
+      const candidateA = upsertReplacementCandidate(boot.db, {
+        servicePlanId,
+        candidateName: "Option A",
+        scorecard: {
+          cost: 70,
+          featureFit: 80,
+          migrationRisk: 60,
+          supportQuality: 75
+        }
+      });
+      const candidateB = upsertReplacementCandidate(boot.db, {
+        servicePlanId,
+        candidateName: "Option B",
+        scorecard: {
+          cost: 85,
+          featureFit: 90,
+          migrationRisk: 80,
+          supportQuality: 88
+        }
+      });
+
+      const detail = getReplacementPlanDetail(boot.db, servicePlanId);
+      expect(detail.aggregation.candidateCount).toBe(2);
+      expect(detail.aggregation.bestCandidateId).toBe(candidateB);
+      expect(detail.aggregation.bestWeightedScore).toBeGreaterThan(
+        detail.candidates.find((entry) => entry.id === candidateA)?.weightedScore ?? 0
+      );
+      expect(detail.aggregation.averageWeightedScore).toBeGreaterThan(0);
+      expect(detail.candidates[0].id).toBe(candidateB);
+
+      const attachmentId = createAttachmentReference(boot.db, {
+        entityType: "service_plan",
+        entityId: servicePlanId,
+        fileName: "comparison.pdf.enc",
+        filePath: "C:/secure/comparison.pdf.enc",
+        contentSha256: "abc123"
+      });
+      const attachments = listAttachmentReferences(boot.db, "service_plan", servicePlanId);
+      expect(attachments).toHaveLength(1);
+      expect(attachments[0].id).toBe(attachmentId);
+      expect(attachments[0].fileName).toBe("comparison.pdf.enc");
+    } finally {
+      boot.db.close();
+    }
+  });
+});

--- a/packages/db/src/replacement-planning.ts
+++ b/packages/db/src/replacement-planning.ts
@@ -1,0 +1,469 @@
+import crypto from "node:crypto";
+
+import type Database from "better-sqlite3-multiple-ciphers";
+
+export type ServicePlanDecisionStatus = "draft" | "reviewed" | "approved" | "rejected";
+export type ServicePlanAction = "keep" | "replace" | "retire";
+export type ServicePlanReasonCode =
+  | "cost"
+  | "security"
+  | "eol"
+  | "consolidation"
+  | "performance"
+  | "other";
+
+export type ReplacementScorecardWeights = {
+  cost: number;
+  featureFit: number;
+  migrationRisk: number;
+  supportQuality: number;
+};
+
+export type ReplacementScorecardInput = {
+  cost: number;
+  featureFit: number;
+  migrationRisk: number;
+  supportQuality: number;
+  weights?: Partial<ReplacementScorecardWeights>;
+};
+
+export type ReplacementCandidateDetail = {
+  id: string;
+  servicePlanId: string;
+  candidateServiceId: string | null;
+  candidateName: string | null;
+  weightedScore: number;
+  scorecard: ReplacementScorecardInput;
+};
+
+export type ReplacementPlanDetail = {
+  servicePlan: {
+    id: string;
+    scenarioId: string;
+    serviceId: string;
+    plannedAction: ServicePlanAction;
+    decisionStatus: ServicePlanDecisionStatus;
+    reasonCode: string | null;
+    replacementRequired: boolean;
+    replacementSelectedServiceId: string | null;
+  };
+  candidates: ReplacementCandidateDetail[];
+  aggregation: {
+    candidateCount: number;
+    averageWeightedScore: number;
+    bestCandidateId: string | null;
+    bestWeightedScore: number | null;
+  };
+};
+
+const DEFAULT_WEIGHTS: ReplacementScorecardWeights = {
+  cost: 0.35,
+  featureFit: 0.3,
+  migrationRisk: 0.2,
+  supportQuality: 0.15
+};
+
+const TRANSITIONS: Record<ServicePlanDecisionStatus, ServicePlanDecisionStatus[]> = {
+  draft: ["reviewed"],
+  reviewed: ["approved", "rejected", "draft"],
+  approved: [],
+  rejected: ["draft"]
+};
+
+function assertScore(value: number, field: string): void {
+  if (!Number.isFinite(value) || value < 0 || value > 100) {
+    throw new Error(`${field} must be a number between 0 and 100.`);
+  }
+}
+
+function resolveWeights(
+  input: Partial<ReplacementScorecardWeights> | undefined
+): ReplacementScorecardWeights {
+  const merged: ReplacementScorecardWeights = {
+    ...DEFAULT_WEIGHTS,
+    ...(input ?? {})
+  };
+  const total = merged.cost + merged.featureFit + merged.migrationRisk + merged.supportQuality;
+  if (Math.abs(total - 1) > 0.001) {
+    throw new Error("Scorecard weights must sum to 1.");
+  }
+  return merged;
+}
+
+export function computeWeightedScore(input: ReplacementScorecardInput): number {
+  assertScore(input.cost, "cost");
+  assertScore(input.featureFit, "featureFit");
+  assertScore(input.migrationRisk, "migrationRisk");
+  assertScore(input.supportQuality, "supportQuality");
+
+  const weights = resolveWeights(input.weights);
+  const weighted =
+    input.cost * weights.cost +
+    input.featureFit * weights.featureFit +
+    input.migrationRisk * weights.migrationRisk +
+    input.supportQuality * weights.supportQuality;
+  return Math.round(weighted * 100) / 100;
+}
+
+export function createServicePlan(
+  db: Database.Database,
+  input: {
+    scenarioId: string;
+    serviceId: string;
+    plannedAction: ServicePlanAction;
+    replacementRequired: boolean;
+    mustReplaceBy?: string;
+  }
+): string {
+  const id = crypto.randomUUID();
+  db.prepare(
+    `
+      INSERT INTO service_plan (
+        id,
+        scenario_id,
+        service_id,
+        planned_action,
+        decision_status,
+        reason_code,
+        must_replace_by,
+        replacement_required,
+        replacement_selected_service_id,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, 'draft', NULL, ?, ?, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `
+  ).run(
+    id,
+    input.scenarioId,
+    input.serviceId,
+    input.plannedAction,
+    input.mustReplaceBy ?? null,
+    input.replacementRequired ? 1 : 0
+  );
+  return id;
+}
+
+export function setReplacementSelection(
+  db: Database.Database,
+  input: {
+    servicePlanId: string;
+    replacementSelectedServiceId: string | null;
+  }
+): void {
+  db.prepare(
+    `
+      UPDATE service_plan
+      SET replacement_selected_service_id = ?,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = ?
+    `
+  ).run(input.replacementSelectedServiceId, input.servicePlanId);
+}
+
+export function transitionServicePlan(
+  db: Database.Database,
+  input: {
+    servicePlanId: string;
+    nextStatus: ServicePlanDecisionStatus;
+    reasonCode?: ServicePlanReasonCode;
+  }
+): void {
+  const current = db
+    .prepare(
+      `
+        SELECT
+          decision_status,
+          planned_action,
+          replacement_required,
+          replacement_selected_service_id
+        FROM service_plan
+        WHERE id = ?
+      `
+    )
+    .get(input.servicePlanId) as
+    | {
+        decision_status: ServicePlanDecisionStatus;
+        planned_action: ServicePlanAction;
+        replacement_required: number;
+        replacement_selected_service_id: string | null;
+      }
+    | undefined;
+
+  if (!current) {
+    throw new Error(`Service plan not found: ${input.servicePlanId}`);
+  }
+  if (!TRANSITIONS[current.decision_status].includes(input.nextStatus)) {
+    throw new Error(
+      `Invalid transition: ${current.decision_status} -> ${input.nextStatus}`
+    );
+  }
+
+  if ((input.nextStatus === "approved" || input.nextStatus === "rejected") && !input.reasonCode) {
+    throw new Error("reasonCode is required when approving or rejecting a service plan.");
+  }
+
+  if (
+    input.nextStatus === "approved" &&
+    current.planned_action === "replace" &&
+    current.replacement_required === 1 &&
+    !current.replacement_selected_service_id
+  ) {
+    throw new Error(
+      "replacementSelectedServiceId is required before approving a replacement-required plan."
+    );
+  }
+
+  db.prepare(
+    `
+      UPDATE service_plan
+      SET decision_status = ?,
+          reason_code = ?,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = ?
+    `
+  ).run(input.nextStatus, input.reasonCode ?? null, input.servicePlanId);
+}
+
+export function upsertReplacementCandidate(
+  db: Database.Database,
+  input: {
+    id?: string;
+    servicePlanId: string;
+    candidateServiceId?: string;
+    candidateName?: string;
+    scorecard: ReplacementScorecardInput;
+  }
+): string {
+  const id = input.id ?? crypto.randomUUID();
+  const weightedScore = computeWeightedScore(input.scorecard);
+  const scorecardJson = JSON.stringify(input.scorecard);
+  const existing = db
+    .prepare("SELECT id FROM replacement_candidate WHERE id = ?")
+    .get(id) as { id: string } | undefined;
+
+  if (existing) {
+    db.prepare(
+      `
+        UPDATE replacement_candidate
+        SET service_plan_id = ?,
+            candidate_service_id = ?,
+            candidate_name = ?,
+            score = ?,
+            scorecard_json = ?,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id = ?
+      `
+    ).run(
+      input.servicePlanId,
+      input.candidateServiceId ?? null,
+      input.candidateName ?? null,
+      weightedScore,
+      scorecardJson,
+      id
+    );
+    return id;
+  }
+
+  db.prepare(
+    `
+      INSERT INTO replacement_candidate (
+        id,
+        service_plan_id,
+        candidate_service_id,
+        candidate_name,
+        score,
+        scorecard_json,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `
+  ).run(
+    id,
+    input.servicePlanId,
+    input.candidateServiceId ?? null,
+    input.candidateName ?? null,
+    weightedScore,
+    scorecardJson
+  );
+  return id;
+}
+
+function parseScorecardJson(value: string | null): ReplacementScorecardInput {
+  if (!value) {
+    return {
+      cost: 0,
+      featureFit: 0,
+      migrationRisk: 0,
+      supportQuality: 0
+    };
+  }
+
+  try {
+    return JSON.parse(value) as ReplacementScorecardInput;
+  } catch {
+    return {
+      cost: 0,
+      featureFit: 0,
+      migrationRisk: 0,
+      supportQuality: 0
+    };
+  }
+}
+
+export function getReplacementPlanDetail(
+  db: Database.Database,
+  servicePlanId: string
+): ReplacementPlanDetail {
+  const servicePlan = db
+    .prepare(
+      `
+        SELECT
+          id,
+          scenario_id,
+          service_id,
+          planned_action,
+          decision_status,
+          reason_code,
+          replacement_required,
+          replacement_selected_service_id
+        FROM service_plan
+        WHERE id = ?
+      `
+    )
+    .get(servicePlanId) as
+    | {
+        id: string;
+        scenario_id: string;
+        service_id: string;
+        planned_action: ServicePlanAction;
+        decision_status: ServicePlanDecisionStatus;
+        reason_code: string | null;
+        replacement_required: number;
+        replacement_selected_service_id: string | null;
+      }
+    | undefined;
+
+  if (!servicePlan) {
+    throw new Error(`Service plan not found: ${servicePlanId}`);
+  }
+
+  const rows = db
+    .prepare(
+      `
+        SELECT
+          id,
+          service_plan_id,
+          candidate_service_id,
+          candidate_name,
+          score,
+          scorecard_json
+        FROM replacement_candidate
+        WHERE service_plan_id = ?
+        ORDER BY score DESC, candidate_name ASC
+      `
+    )
+    .all(servicePlanId) as Array<{
+    id: string;
+    service_plan_id: string;
+    candidate_service_id: string | null;
+    candidate_name: string | null;
+    score: number | null;
+    scorecard_json: string | null;
+  }>;
+
+  const candidates: ReplacementCandidateDetail[] = rows.map((row) => ({
+    id: row.id,
+    servicePlanId: row.service_plan_id,
+    candidateServiceId: row.candidate_service_id,
+    candidateName: row.candidate_name,
+    weightedScore: row.score ?? 0,
+    scorecard: parseScorecardJson(row.scorecard_json)
+  }));
+
+  const candidateCount = candidates.length;
+  const sum = candidates.reduce((acc, row) => acc + row.weightedScore, 0);
+  const best = candidates[0];
+
+  return {
+    servicePlan: {
+      id: servicePlan.id,
+      scenarioId: servicePlan.scenario_id,
+      serviceId: servicePlan.service_id,
+      plannedAction: servicePlan.planned_action,
+      decisionStatus: servicePlan.decision_status,
+      reasonCode: servicePlan.reason_code,
+      replacementRequired: servicePlan.replacement_required === 1,
+      replacementSelectedServiceId: servicePlan.replacement_selected_service_id
+    },
+    candidates,
+    aggregation: {
+      candidateCount,
+      averageWeightedScore: candidateCount > 0 ? Math.round((sum / candidateCount) * 100) / 100 : 0,
+      bestCandidateId: best?.id ?? null,
+      bestWeightedScore: best?.weightedScore ?? null
+    }
+  };
+}
+
+export function createAttachmentReference(
+  db: Database.Database,
+  input: {
+    entityType: string;
+    entityId: string;
+    fileName: string;
+    filePath: string;
+    contentSha256: string;
+  }
+): string {
+  const id = crypto.randomUUID();
+  db.prepare(
+    `
+      INSERT INTO attachment (
+        id,
+        entity_type,
+        entity_id,
+        file_name,
+        file_path,
+        content_sha256,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+    `
+  ).run(
+    id,
+    input.entityType,
+    input.entityId,
+    input.fileName,
+    input.filePath,
+    input.contentSha256
+  );
+  return id;
+}
+
+export function listAttachmentReferences(
+  db: Database.Database,
+  entityType: string,
+  entityId: string
+): Array<{
+  id: string;
+  fileName: string;
+  filePath: string;
+  contentSha256: string | null;
+}> {
+  return db
+    .prepare(
+      `
+        SELECT id, file_name AS fileName, file_path AS filePath, content_sha256 AS contentSha256
+        FROM attachment
+        WHERE entity_type = ?
+          AND entity_id = ?
+        ORDER BY created_at DESC
+      `
+    )
+    .all(entityType, entityId) as Array<{
+    id: string;
+    fileName: string;
+    filePath: string;
+    contentSha256: string | null;
+  }>;
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -159,6 +159,7 @@ export const replacementCandidate = sqliteTable("replacement_candidate", {
   candidateServiceId: text("candidate_service_id"),
   candidateName: text("candidate_name"),
   score: integer("score"),
+  scorecardJson: text("scorecard_json"),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at").notNull()
 });


### PR DESCRIPTION
## Summary
- add replacement planning domain module with workflow state transitions, required-field enforcement, candidate scorecards, and aggregation detail query
- add schema/migration support for persisted replacement scorecards (