### PR TITLE
feat: implement F1 reporting datasets and dashboard UI

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import {
   bootstrapEncryptedDatabase,
+  buildDashboardDataset,
   buildMonthlyVarianceDataset,
   createEncryptedBackup,
   getReplacementPlanDetail,
@@ -692,6 +693,9 @@ function setupIpcHandlers(requestExit: () => void): void {
   ipcMain.handle("reports.query", async (_event, payload: unknown) => {
     const parsed = parseReportsQueryPayload(payload);
     const handle = requireDatabaseHandle();
+    if (parsed.query === "dashboard.summary") {
+      return buildDashboardDataset(handle.db, parsed.scenarioId);
+    }
     if (parsed.query === "variance.monthly") {
       return buildMonthlyVarianceDataset(handle.db, parsed.scenarioId);
     }

--- a/apps/renderer/src/reporting.test.ts
+++ b/apps/renderer/src/reporting.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeDashboardTotals,
+  getForecastStaleIndicator,
+  type DashboardDataset
+} from "./reporting";
+
+const fixtureDataset: DashboardDataset = {
+  scenarioId: "baseline",
+  staleForecast: false,
+  spendTrend: [
+    { month: "2026-01", forecastMinor: 10000, actualMinor: 10000 },
+    { month: "2026-02", forecastMinor: 15000, actualMinor: 16000 },
+    { month: "2026-03", forecastMinor: 15000, actualMinor: 15000 }
+  ],
+  variance: [
+    {
+      month: "2026-01",
+      forecastMinor: 10000,
+      actualMinor: 10000,
+      varianceMinor: 0,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    },
+    {
+      month: "2026-02",
+      forecastMinor: 15000,
+      actualMinor: 16000,
+      varianceMinor: 1000,
+      unmatchedActualMinor: 1000,
+      unmatchedCount: 1
+    },
+    {
+      month: "2026-03",
+      forecastMinor: 15000,
+      actualMinor: 15000,
+      varianceMinor: 0,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    }
+  ],
+  renewals: [{ month: "2026-05", count: 1 }],
+  growth: [
+    { month: "2026-01", forecastMinor: 10000, growthPct: null },
+    { month: "2026-02", forecastMinor: 15000, growthPct: 50 },
+    { month: "2026-03", forecastMinor: 15000, growthPct: 0 }
+  ],
+  taggingCompleteness: {
+    totalExpenseLines: 2,
+    taggedExpenseLines: 1,
+    completenessRatio: 0.5
+  },
+  replacementStatus: {
+    totalPlans: 2,
+    replacementRequiredOpen: 1,
+    byStatus: [
+      { status: "approved", count: 1 },
+      { status: "reviewed", count: 1 }
+    ]
+  },
+  narrativeBlocks: [
+    { id: "n1", title: "Summary", body: "..." }
+  ]
+};
+
+describe("reporting helpers", () => {
+  it("keeps chart totals aligned with source dataset totals", () => {
+    const totals = computeDashboardTotals(fixtureDataset);
+    expect(totals).toEqual({
+      forecastMinor: 40000,
+      actualMinor: 41000,
+      varianceMinor: 1000
+    });
+  });
+
+  it("exposes stale forecast indicator when forecast is outdated", () => {
+    const stale = {
+      ...fixtureDataset,
+      staleForecast: true
+    };
+    expect(getForecastStaleIndicator(stale)).toContain("stale");
+    expect(getForecastStaleIndicator(fixtureDataset)).toBeNull();
+  });
+});

--- a/apps/renderer/src/reporting.ts
+++ b/apps/renderer/src/reporting.ts
@@ -1,0 +1,64 @@
+export type DashboardDataset = {
+  scenarioId: string;
+  staleForecast: boolean;
+  spendTrend: Array<{
+    month: string;
+    forecastMinor: number;
+    actualMinor: number;
+  }>;
+  variance: Array<{
+    month: string;
+    forecastMinor: number;
+    actualMinor: number;
+    varianceMinor: number;
+    unmatchedActualMinor: number;
+    unmatchedCount: number;
+  }>;
+  renewals: Array<{
+    month: string;
+    count: number;
+  }>;
+  growth: Array<{
+    month: string;
+    forecastMinor: number;
+    growthPct: number | null;
+  }>;
+  taggingCompleteness: {
+    totalExpenseLines: number;
+    taggedExpenseLines: number;
+    completenessRatio: number;
+  };
+  replacementStatus: {
+    totalPlans: number;
+    replacementRequiredOpen: number;
+    byStatus: Array<{ status: string; count: number }>;
+  };
+  narrativeBlocks: Array<{
+    id: string;
+    title: string;
+    body: string;
+  }>;
+};
+
+export function computeDashboardTotals(dataset: DashboardDataset): {
+  forecastMinor: number;
+  actualMinor: number;
+  varianceMinor: number;
+} {
+  return dataset.spendTrend.reduce(
+    (totals, row) => {
+      totals.forecastMinor += row.forecastMinor;
+      totals.actualMinor += row.actualMinor;
+      totals.varianceMinor += row.actualMinor - row.forecastMinor;
+      return totals;
+    },
+    { forecastMinor: 0, actualMinor: 0, varianceMinor: 0 }
+  );
+}
+
+export function getForecastStaleIndicator(dataset: DashboardDataset): string | null {
+  if (!dataset.staleForecast) {
+    return null;
+  }
+  return "Forecast data is stale and should be re-materialized.";
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -62,5 +62,15 @@ export {
   type ServicePlanDecisionStatus,
   type ServicePlanReasonCode
 } from "./replacement-planning";
+export {
+  buildDashboardDataset,
+  type DashboardDataset,
+  type GrowthRow,
+  type NarrativeBlock,
+  type RenewalRow,
+  type ReplacementStatusSummary,
+  type SpendTrendRow,
+  type TaggingCompleteness
+} from "./reporting";
 export * as schema from "./schema";
 

--- a/packages/db/src/reporting.test.ts
+++ b/packages/db/src/reporting.test.ts
@@ -1,0 +1,211 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { bootstrapEncryptedDatabase } from "./encrypted-db";
+import { materializeScenarioOccurrences, markForecastStale } from "./forecast-engine";
+import { runMigrations } from "./migrations";
+import { buildDashboardDataset } from "./reporting";
+import {
+  createServicePlan,
+  setReplacementSelection,
+  transitionServicePlan
+} from "./replacement-planning";
+import { BudgetCrudRepository } from "./repositories";
+import { ingestActualTransactions } from "./variance";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-reporting-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("dashboard reporting datasets", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("builds expected dataset aggregates for spend, variance, renewals, tags, and replacement status", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      const repo = new BudgetCrudRepository(boot.db);
+      const vendorId = repo.createVendor({ name: "Vendor A" });
+      const serviceId = repo.createService({
+        vendorId,
+        name: "Service A",
+        status: "active"
+      });
+      const replacementServiceId = repo.createService({
+        vendorId,
+        name: "Service B",
+        status: "active"
+      });
+      const contractId = repo.createContract({
+        serviceId,
+        contractNumber: "C-100",
+        renewalDate: "2026-05-01",
+        renewalType: "manual",
+        noticePeriodDays: 60
+      });
+
+      const expenseA = repo.createExpenseLineWithOptionalRecurrence(
+        {
+          scenarioId: "baseline",
+          serviceId,
+          contractId,
+          name: "Primary subscription",
+          expenseType: "recurring",
+          status: "planned",
+          amountMinor: 10000,
+          currency: "USD",
+          startDate: "2026-01-01"
+        },
+        {
+          expenseLineId: "ignored",
+          frequency: "monthly",
+          interval: 1,
+          dayOfMonth: 1,
+          anchorDate: "2026-01-01"
+        }
+      );
+      const expenseB = repo.createExpenseLineWithOptionalRecurrence(
+        {
+          scenarioId: "baseline",
+          serviceId,
+          contractId,
+          name: "Secondary subscription",
+          expenseType: "recurring",
+          status: "planned",
+          amountMinor: 5000,
+          currency: "USD",
+          startDate: "2026-02-01"
+        },
+        {
+          expenseLineId: "ignored",
+          frequency: "monthly",
+          interval: 1,
+          dayOfMonth: 1,
+          anchorDate: "2026-02-01"
+        }
+      );
+
+      const dimensionId = repo.createDimension({
+        name: "Owner",
+        mode: "single_select",
+        required: false
+      });
+      const tagId = repo.createTag({ dimensionId, name: "IT" });
+      repo.assignTagToEntity({
+        entityType: "expense_line",
+        entityId: expenseA,
+        dimensionId,
+        tagId
+      });
+
+      materializeScenarioOccurrences(boot.db, "baseline", 2);
+      ingestActualTransactions(boot.db, [
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-01-01",
+          amountMinor: 10000,
+          currency: "USD",
+          description: "Jan invoice"
+        },
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-02-01",
+          amountMinor: 16000,
+          currency: "USD",
+          description: "Feb overage"
+        },
+        {
+          scenarioId: "baseline",
+          serviceId,
+          transactionDate: "2026-03-01",
+          amountMinor: 15000,
+          currency: "USD",
+          description: "Mar invoice"
+        }
+      ]);
+
+      const planA = createServicePlan(boot.db, {
+        scenarioId: "baseline",
+        serviceId,
+        plannedAction: "replace",
+        replacementRequired: true
+      });
+      const planB = createServicePlan(boot.db, {
+        scenarioId: "baseline",
+        serviceId,
+        plannedAction: "keep",
+        replacementRequired: false
+      });
+      transitionServicePlan(boot.db, {
+        servicePlanId: planA,
+        nextStatus: "reviewed"
+      });
+      setReplacementSelection(boot.db, {
+        servicePlanId: planA,
+        replacementSelectedServiceId: replacementServiceId
+      });
+      transitionServicePlan(boot.db, {
+        servicePlanId: planA,
+        nextStatus: "approved",
+        reasonCode: "cost"
+      });
+      transitionServicePlan(boot.db, {
+        servicePlanId: planB,
+        nextStatus: "reviewed"
+      });
+
+      const dashboard = buildDashboardDataset(boot.db, "baseline");
+
+      expect(dashboard.spendTrend.length).toBeGreaterThan(0);
+      expect(dashboard.variance.length).toBe(dashboard.spendTrend.length);
+      expect(dashboard.renewals).toEqual([{ month: "2026-05", count: 1 }]);
+      expect(dashboard.taggingCompleteness.totalExpenseLines).toBe(2);
+      expect(dashboard.taggingCompleteness.taggedExpenseLines).toBe(1);
+      expect(dashboard.taggingCompleteness.completenessRatio).toBe(0.5);
+      expect(dashboard.replacementStatus.totalPlans).toBe(2);
+      expect(dashboard.replacementStatus.byStatus.some((row) => row.status === "approved")).toBe(
+        true
+      );
+      expect(dashboard.narrativeBlocks.length).toBe(4);
+
+      const forecastTotal = dashboard.spendTrend.reduce((sum, row) => sum + row.forecastMinor, 0);
+      const varianceForecastTotal = dashboard.variance.reduce(
+        (sum, row) => sum + row.forecastMinor,
+        0
+      );
+      expect(forecastTotal).toBe(varianceForecastTotal);
+
+      expect(expenseB).toBeTruthy();
+    } finally {
+      boot.db.close();
+    }
+  });
+
+  it("flags stale forecast state when forecast is outdated", () => {
+    const dataDir = createTempDir();
+    const boot = bootstrapEncryptedDatabase(dataDir);
+    try {
+      runMigrations(boot.db);
+      markForecastStale(boot.db);
+
+      const dashboard = buildDashboardDataset(boot.db, "baseline");
+      expect(dashboard.staleForecast).toBe(true);
+    } finally {
+      boot.db.close();
+    }
+  });
+});

--- a/packages/db/src/reporting.ts
+++ b/packages/db/src/reporting.ts
@@ -1,0 +1,233 @@
+import { buildMonthlyVarianceDataset, type MonthlyVarianceRow } from "./variance";
+import type Database from "better-sqlite3-multiple-ciphers";
+
+export type SpendTrendRow = {
+  month: string;
+  forecastMinor: number;
+  actualMinor: number;
+};
+
+export type RenewalRow = {
+  month: string;
+  count: number;
+};
+
+export type GrowthRow = {
+  month: string;
+  forecastMinor: number;
+  growthPct: number | null;
+};
+
+export type TaggingCompleteness = {
+  totalExpenseLines: number;
+  taggedExpenseLines: number;
+  completenessRatio: number;
+};
+
+export type ReplacementStatusRow = {
+  status: string;
+  count: number;
+};
+
+export type ReplacementStatusSummary = {
+  totalPlans: number;
+  replacementRequiredOpen: number;
+  byStatus: ReplacementStatusRow[];
+};
+
+export type NarrativeBlock = {
+  id: string;
+  title: string;
+  body: string;
+};
+
+export type DashboardDataset = {
+  scenarioId: string;
+  staleForecast: boolean;
+  spendTrend: SpendTrendRow[];
+  renewals: RenewalRow[];
+  growth: GrowthRow[];
+  variance: MonthlyVarianceRow[];
+  taggingCompleteness: TaggingCompleteness;
+  replacementStatus: ReplacementStatusSummary;
+  narrativeBlocks: NarrativeBlock[];
+};
+
+function buildSpendTrend(variance: MonthlyVarianceRow[]): SpendTrendRow[] {
+  return variance.map((row) => ({
+    month: row.month,
+    forecastMinor: row.forecastMinor,
+    actualMinor: row.actualMinor
+  }));
+}
+
+function buildGrowthSeries(spendTrend: SpendTrendRow[]): GrowthRow[] {
+  return spendTrend.map((row, index) => {
+    if (index === 0) {
+      return { month: row.month, forecastMinor: row.forecastMinor, growthPct: null };
+    }
+    const previous = spendTrend[index - 1];
+    if (previous.forecastMinor === 0) {
+      return { month: row.month, forecastMinor: row.forecastMinor, growthPct: null };
+    }
+    return {
+      month: row.month,
+      forecastMinor: row.forecastMinor,
+      growthPct: ((row.forecastMinor - previous.forecastMinor) / previous.forecastMinor) * 100
+    };
+  });
+}
+
+function queryRenewals(db: Database.Database): RenewalRow[] {
+  return db
+    .prepare(
+      `
+        SELECT substr(renewal_date, 1, 7) AS month, COUNT(*) AS count
+        FROM contract
+        WHERE renewal_date IS NOT NULL
+        GROUP BY month
+        ORDER BY month
+      `
+    )
+    .all() as RenewalRow[];
+}
+
+function queryTaggingCompleteness(
+  db: Database.Database,
+  scenarioId: string
+): TaggingCompleteness {
+  const totals = db
+    .prepare(
+      `
+        SELECT
+          COUNT(*) AS total,
+          SUM(
+            CASE
+              WHEN EXISTS (
+                SELECT 1
+                FROM tag_assignment ta
+                WHERE ta.entity_type = 'expense_line'
+                  AND ta.entity_id = e.id
+              ) THEN 1
+              ELSE 0
+            END
+          ) AS tagged
+        FROM expense_line e
+        WHERE e.scenario_id = ?
+          AND e.deleted_at IS NULL
+      `
+    )
+    .get(scenarioId) as { total: number; tagged: number | null };
+
+  const total = totals.total ?? 0;
+  const tagged = totals.tagged ?? 0;
+  return {
+    totalExpenseLines: total,
+    taggedExpenseLines: tagged,
+    completenessRatio: total === 0 ? 1 : tagged / total
+  };
+}
+
+function queryReplacementStatus(
+  db: Database.Database,
+  scenarioId: string
+): ReplacementStatusSummary {
+  const byStatus = db
+    .prepare(
+      `
+        SELECT decision_status AS status, COUNT(*) AS count
+        FROM service_plan
+        WHERE scenario_id = ?
+        GROUP BY decision_status
+        ORDER BY decision_status
+      `
+    )
+    .all(scenarioId) as ReplacementStatusRow[];
+
+  const replacementRequiredOpen = db
+    .prepare(
+      `
+        SELECT COUNT(*) AS count
+        FROM service_plan
+        WHERE scenario_id = ?
+          AND replacement_required = 1
+          AND replacement_selected_service_id IS NULL
+      `
+    )
+    .get(scenarioId) as { count: number };
+
+  return {
+    totalPlans: byStatus.reduce((sum, row) => sum + row.count, 0),
+    replacementRequiredOpen: replacementRequiredOpen.count,
+    byStatus
+  };
+}
+
+function buildNarratives(input: {
+  staleForecast: boolean;
+  spendTrend: SpendTrendRow[];
+  renewals: RenewalRow[];
+  taggingCompleteness: TaggingCompleteness;
+  replacementStatus: ReplacementStatusSummary;
+}): NarrativeBlock[] {
+  const totalForecast = input.spendTrend.reduce((sum, row) => sum + row.forecastMinor, 0);
+  const totalActual = input.spendTrend.reduce((sum, row) => sum + row.actualMinor, 0);
+  const delta = totalActual - totalForecast;
+
+  return [
+    {
+      id: "spend-summary",
+      title: "Spend Summary",
+      body: `Forecast ${(totalForecast / 100).toFixed(2)} USD vs actual ${(totalActual / 100).toFixed(2)} USD (delta ${(delta / 100).toFixed(2)} USD).`
+    },
+    {
+      id: "renewal-summary",
+      title: "Renewals",
+      body: `${input.renewals.reduce((sum, row) => sum + row.count, 0)} renewals are currently scheduled.`
+    },
+    {
+      id: "quality-summary",
+      title: "Data Quality",
+      body: `Tagging completeness is ${(input.taggingCompleteness.completenessRatio * 100).toFixed(1)}%.${input.staleForecast ? " Forecast is marked stale." : ""}`
+    },
+    {
+      id: "replacement-summary",
+      title: "Replacement Status",
+      body: `${input.replacementStatus.replacementRequiredOpen} replacement-required plans remain without a selected replacement.`
+    }
+  ];
+}
+
+export function buildDashboardDataset(
+  db: Database.Database,
+  scenarioId: string = "baseline"
+): DashboardDataset {
+  const variance = buildMonthlyVarianceDataset(db, scenarioId);
+  const spendTrend = buildSpendTrend(variance);
+  const renewals = queryRenewals(db);
+  const growth = buildGrowthSeries(spendTrend);
+  const taggingCompleteness = queryTaggingCompleteness(db, scenarioId);
+  const replacementStatus = queryReplacementStatus(db, scenarioId);
+  const metaRow = db
+    .prepare("SELECT forecast_stale FROM meta WHERE id = 1")
+    .get() as { forecast_stale: number | null } | undefined;
+  const staleForecast = (metaRow?.forecast_stale ?? 0) === 1;
+
+  return {
+    scenarioId,
+    staleForecast,
+    spendTrend,
+    renewals,
+    growth,
+    variance,
+    taggingCompleteness,
+    replacementStatus,
+    narrativeBlocks: buildNarratives({
+      staleForecast,
+      spendTrend,
+      renewals,
+      taggingCompleteness,
+      replacementStatus
+    })
+  };
+}


### PR DESCRIPTION
## Summary
- add canonical reporting dataset builder in @budgetit/db for spend trend, renewals, growth, variance, tagging completeness, replacement status, and narrative blocks
- add DB fixture tests validating aggregate correctness and stale-forecast behavior
- extend eports.query with dashboard.summary
- add renderer reporting helpers + tests for chart/total consistency and stale indicator behavior
- add dashboard section in renderer with table/gauge-style summary and narrative blocks

## Tests
- 
pm --workspace @budgetit/db run lint
- 
pm --workspace @budgetit/db run typecheck
- 
pm --workspace @budgetit/db run test
- 
pm --workspace @budgetit/renderer run lint
- 
pm --workspace @budgetit/renderer run typecheck
- 
pm --workspace @budgetit/renderer run test
- 
pm --workspace @budgetit/db run build && npm --workspace @budgetit/desktop run typecheck
- 
pm --workspace @budgetit/desktop run test
- 
pm run lint
- 
pm run typecheck
- 
pm run test
- 
pm run build

Closes #28