### PR TITLE
docs: implement F4 release hardening and operator runbooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Build NSIS artifact
         run: npm run dist:win
 
+      - name: Run packaged smoke checks
+        run: npm run smoke:packaged
+
       - name: Validate artifact exists
         shell: powershell
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Build release artifacts
         run: npm run release:win
 
+      - name: Run packaged smoke checks
+        run: npm run smoke:packaged
+
       - name: Validate artifacts and create checksum
         shell: powershell
         run: |

--- a/apps/desktop/src/release-hardening.test.ts
+++ b/apps/desktop/src/release-hardening.test.ts
@@ -1,0 +1,46 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_RUNTIME_SETTINGS } from "./lifecycle";
+import { readRuntimeSettings, writeRuntimeSettings } from "./settings-store";
+
+const tempRoots: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "budgetit-release-hardening-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("release hardening runtime defaults", () => {
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses startup and tray defaults in packaged runtime settings", () => {
+    expect(DEFAULT_RUNTIME_SETTINGS.startWithWindows).toBe(true);
+    expect(DEFAULT_RUNTIME_SETTINGS.minimizeToTray).toBe(true);
+  });
+
+  it("persists startup and tray overrides across restarts", () => {
+    const dir = createTempDir();
+    const settingsPath = path.join(dir, "runtime-settings.json");
+    writeRuntimeSettings(settingsPath, {
+      startWithWindows: false,
+      minimizeToTray: false,
+      teamsEnabled: true,
+      teamsWebhookUrl: "https://example.test/webhook"
+    });
+
+    const restored = readRuntimeSettings(settingsPath);
+    expect(restored.startWithWindows).toBe(false);
+    expect(restored.minimizeToTray).toBe(false);
+    expect(restored.teamsEnabled).toBe(true);
+    expect(restored.teamsWebhookUrl).toBe("https://example.test/webhook");
+  });
+});

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -22,6 +22,7 @@ Behavior:
   - `test`
   - `build`
 - Runs on `windows-latest` and uploads optional test artifacts (`coverage`, `junit.xml`, `test-results`).
+- Builds Windows NSIS artifact in a follow-up smoke job and runs `npm run smoke:packaged`.
 
 ## Release workflow (CD)
 
@@ -35,6 +36,7 @@ Behavior:
 - Validates tag and project scaffold.
 - Ensures pushed tag commit is contained in `origin/main`.
 - Runs quality gates (`lint`, `typecheck`, `test`, `build`) before packaging.
+- Runs packaged smoke checks (`npm run smoke:packaged`) after artifact creation.
 - Resolves packaging script from the first existing script in:
   - `release:win`
   - `dist:win`
@@ -70,7 +72,8 @@ At minimum:
     "typecheck": "...",
     "test": "...",
     "build": "...",
-    "release:win": "..."
+    "release:win": "...",
+    "smoke:packaged": "..."
   }
 }
 ```

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -1,0 +1,37 @@
+# BudgetIT Operator Runbook
+
+This runbook is for single-device Windows operation of BudgetIT.
+
+## Backup
+
+1. Open BudgetIT and run backup from the runtime panel.
+2. Store backup and manifest files together.
+3. Verify backup freshness alert state is healthy.
+4. Optional: run test-restore verification before release cut.
+
+## Recovery Key
+
+1. Export the one-time recovery key after first-run setup.
+2. Store recovery key in secured offline location.
+3. If machine migration occurs, import recovery key before opening DB.
+4. Rotate DB key with rekey workflow after any key-handling incident.
+
+## Restore
+
+1. Select backup file and matching manifest.
+2. Run restore and wait for integrity/schema checks.
+3. Confirm the post-restore banner:
+   - restored timestamp
+   - source mutation timestamp (“data current as of”)
+4. Validate key record counts (vendors, services, contracts, expenses).
+
+## Rollback Dry-Run
+
+1. Install latest staging build in clean Windows VM.
+2. Seed sample data, create backup, and export report artifacts.
+3. Install previous release build over VM image snapshot.
+4. Restore backup and verify:
+   - app launches to tray
+   - alerts list available
+   - reports and exports still load
+5. Record dry-run result before production tag publish.

--- a/docs/release-hardening.md
+++ b/docs/release-hardening.md
@@ -1,0 +1,31 @@
+# Release Hardening Checklist
+
+This checklist is run before any production `v*` tag is published.
+
+## Packaging QA
+
+1. Confirm CI quality job passed (`lint`, `typecheck`, `test`, `build`).
+2. Confirm Windows NSIS artifact exists in `dist/release/*.exe`.
+3. Confirm installer smoke checks passed (`npm run smoke:packaged`).
+4. Confirm SHA256 checksum file was generated (`dist/release/SHA256SUMS.txt`).
+5. Confirm release notes include upgrade and rollback guidance.
+
+## Startup Defaults and Overrides
+
+1. Verify packaged defaults:
+   - `startWithWindows = true`
+   - `minimizeToTray = true`
+2. Verify user overrides persist after restart:
+   - toggle startup/tray options
+   - restart app
+   - confirm persisted values in Settings UI
+3. Verify explicit tray `Exit` ends process and scheduler.
+
+## Rollback Notes
+
+1. Keep previous installer artifact and its checksum.
+2. If release fails in production:
+   - install previous known-good version
+   - restore latest valid backup
+   - verify “data current as of” banner
+3. Record rollback event in release notes and incident log.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "npm run test --workspaces --if-present",
     "build": "npm run build --workspace @budgetit/db && npm run build --workspaces --if-present",
     "dist:win": "npm run build && electron-builder --config electron-builder.yml --win nsis --publish never",
-    "release:win": "npm run dist:win"
+    "release:win": "npm run dist:win",
+    "smoke:packaged": "powershell -ExecutionPolicy Bypass -File scripts/release-smoke.ps1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/scripts/release-smoke.ps1
+++ b/scripts/release-smoke.ps1
@@ -1,0 +1,50 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+Write-Host "Running packaged smoke checks..."
+
+$artifactFiles = @(Get-ChildItem -Path "dist/release" -File -Filter "*.exe" -ErrorAction SilentlyContinue)
+if (-not $artifactFiles -or $artifactFiles.Count -eq 0) {
+  throw "No Windows installer artifact found in dist/release."
+}
+
+$requiredDocs = @(
+  "docs/release-hardening.md",
+  "docs/operations-runbook.md"
+)
+
+foreach ($docPath in $requiredDocs) {
+  if (-not (Test-Path $docPath)) {
+    throw "Required release doc missing: $docPath"
+  }
+}
+
+$releaseDoc = Get-Content -Raw "docs/release-hardening.md"
+$runbookDoc = Get-Content -Raw "docs/operations-runbook.md"
+
+$releaseRequiredSections = @(
+  "## Packaging QA",
+  "## Startup Defaults and Overrides",
+  "## Rollback Notes"
+)
+
+foreach ($section in $releaseRequiredSections) {
+  if (-not $releaseDoc.Contains($section)) {
+    throw "Missing section in docs/release-hardening.md: $section"
+  }
+}
+
+$runbookRequiredSections = @(
+  "## Backup",
+  "## Recovery Key",
+  "## Restore",
+  "## Rollback Dry-Run"
+)
+
+foreach ($section in $runbookRequiredSections) {
+  if (-not $runbookDoc.Contains($section)) {
+    throw "Missing section in docs/operations-runbook.md: $section"
+  }
+}
+
+Write-Host "Packaged smoke checks passed."


### PR DESCRIPTION
## Summary
- add release hardening checklist and operator runbook docs for backup/recovery/restore/rollback
- add packaged smoke script (
pm run smoke:packaged) validating artifact presence and required runbook sections
- wire packaged smoke checks into CI and release workflows
- add desktop test for startup/tray defaults and override persistence
- update CI/CD docs with smoke workflow expectations

## Tests
- 
pm --workspace @budgetit/desktop run lint
- 
pm --workspace @budgetit/desktop run typecheck
- 
pm --workspace @budgetit/desktop run test
- 
pm run smoke:packaged (validated script logic with local smoke artifact)
- 
pm run lint
- 
pm run typecheck
- 
pm run test
- 
pm run build

Closes #31