### PR TITLE
[U2] Adopt Fluent UI theme tokens and shared primitives

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -9,6 +9,7 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@fluentui/react-components": "^9.73.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.13.1"

--- a/apps/renderer/src/app/AppShell.tsx
+++ b/apps/renderer/src/app/AppShell.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from "react";
+import { Button, Input, Select, Text } from "@fluentui/react-components";
 import { NavLink, useLocation } from "react-router-dom";
 
 import { NAV_ROUTES, resolveRouteLabel } from "./routes";
@@ -28,27 +29,29 @@ export function AppShell({ children }: PropsWithChildren) {
       </aside>
       <div className="desktop-shell__content">
         <header className="desktop-shell__topbar">
-          <h1 className="desktop-shell__title" data-testid="page-title">
-            {pageTitle}
-          </h1>
-          <select
-            aria-label="Scenario selector"
-            className="desktop-shell__toolbar-select"
-            defaultValue="baseline"
+          <Text
+            as="h1"
+            className="desktop-shell__title"
+            data-testid="page-title"
+            weight="semibold"
+            size={500}
           >
+            {pageTitle}
+          </Text>
+          <Select aria-label="Scenario selector" className="desktop-shell__toolbar-select" defaultValue="baseline">
             <option value="baseline">Baseline</option>
             <option value="draft">Draft</option>
             <option value="approved">Approved</option>
-          </select>
-          <input
+          </Select>
+          <Input
             aria-label="Global search"
             className="desktop-shell__toolbar-input"
             placeholder="Search (Ctrl+K)"
             type="search"
           />
-          <button className="desktop-shell__toolbar-button" type="button">
+          <Button appearance="secondary" className="desktop-shell__toolbar-button" type="button">
             Create
-          </button>
+          </Button>
         </header>
         <main className="desktop-shell__page">{children}</main>
       </div>

--- a/apps/renderer/src/app/app-shell.test.tsx
+++ b/apps/renderer/src/app/app-shell.test.tsx
@@ -28,7 +28,9 @@ describe("AppShell", () => {
 
     expect(screen.getByLabelText("Primary navigation")).toBeInTheDocument();
     expect(screen.getByTestId("page-title")).toHaveTextContent("Dashboard");
-    expect(screen.getByRole("heading", { level: 2, name: "Dashboard" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Dashboard workspace is being upgraded")
+    ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Alerts" })).toBeInTheDocument();
   });
 
@@ -39,6 +41,8 @@ describe("AppShell", () => {
     renderAt("/alerts");
 
     expect(screen.getByTestId("page-title")).toHaveTextContent("Alerts");
-    expect(screen.getByRole("heading", { level: 2, name: "Alerts" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Alerts workspace is being upgraded")
+    ).toBeInTheDocument();
   });
 });

--- a/apps/renderer/src/features/common/FeaturePlaceholderPage.tsx
+++ b/apps/renderer/src/features/common/FeaturePlaceholderPage.tsx
@@ -1,3 +1,7 @@
+import { Button } from "@fluentui/react-components";
+
+import { EmptyState, PageHeader } from "../../ui/primitives";
+
 type FeaturePlaceholderPageProps = {
   title: string;
   description: string;
@@ -9,8 +13,18 @@ export function FeaturePlaceholderPage({
 }: FeaturePlaceholderPageProps) {
   return (
     <section style={{ padding: "1rem 1.25rem" }}>
-      <h2 style={{ marginTop: 0 }}>{title}</h2>
-      <p style={{ color: "#57606a", maxWidth: "72ch" }}>{description}</p>
+      <PageHeader title={title} subtitle={description} />
+      <div style={{ marginTop: "1rem" }}>
+        <EmptyState
+          title={`${title} workspace is being upgraded`}
+          description="This page has been scaffolded and moved into the routed app shell. Feature-specific workflows will be completed in the next UI issues."
+          action={
+            <Button appearance="secondary" size="small">
+              See Implementation Plan
+            </Button>
+          }
+        />
+      </div>
     </section>
   );
 }

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -1,18 +1,22 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { FluentProvider } from "@fluentui/react-components";
 import { BrowserRouter } from "react-router-dom";
 
 import { AppShell } from "./app/AppShell";
 import { AppRoutes } from "./app/routes";
 import "./App.css";
+import { budgetItLightTheme } from "./ui/theme";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <AppShell>
-        <AppRoutes />
-      </AppShell>
-    </BrowserRouter>
+    <FluentProvider theme={budgetItLightTheme}>
+      <BrowserRouter>
+        <AppShell>
+          <AppRoutes />
+        </AppShell>
+      </BrowserRouter>
+    </FluentProvider>
   </React.StrictMode>
 );
 

--- a/apps/renderer/src/ui/primitives/ConfirmDialog.tsx
+++ b/apps/renderer/src/ui/primitives/ConfirmDialog.tsx
@@ -1,0 +1,56 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle
+} from "@fluentui/react-components";
+
+type ConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  message: string;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  confirmLabel?: string;
+};
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  onOpenChange,
+  onConfirm,
+  confirmLabel = "Confirm"
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(_, data) => {
+        onOpenChange(data.open);
+      }}
+    >
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogContent>{message}</DialogContent>
+          <DialogActions>
+            <Button
+              appearance="secondary"
+              onClick={() => {
+                onOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button appearance="primary" onClick={onConfirm}>
+              {confirmLabel}
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+}

--- a/apps/renderer/src/ui/primitives/EmptyState.tsx
+++ b/apps/renderer/src/ui/primitives/EmptyState.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+import { Card, Text } from "@fluentui/react-components";
+
+type EmptyStateProps = {
+  title: string;
+  description: string;
+  action?: ReactNode;
+};
+
+export function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <Card style={{ padding: "1rem", gap: "0.5rem" }}>
+      <Text weight="semibold">{title}</Text>
+      <Text style={{ color: "#57606a" }}>{description}</Text>
+      {action ? <div>{action}</div> : null}
+    </Card>
+  );
+}

--- a/apps/renderer/src/ui/primitives/EntityTable.tsx
+++ b/apps/renderer/src/ui/primitives/EntityTable.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow
+} from "@fluentui/react-components";
+
+import { EmptyState } from "./EmptyState";
+
+export type EntityTableColumn<Row> = {
+  id: string;
+  header: string;
+  renderCell: (row: Row) => ReactNode;
+};
+
+type EntityTableProps<Row> = {
+  columns: Array<EntityTableColumn<Row>>;
+  rows: Row[];
+  getRowId: (row: Row, index: number) => string;
+  emptyTitle?: string;
+  emptyDescription?: string;
+};
+
+export function EntityTable<Row>({
+  columns,
+  rows,
+  getRowId,
+  emptyTitle = "No records yet",
+  emptyDescription = "Add or import data to populate this table."
+}: EntityTableProps<Row>) {
+  if (rows.length === 0) {
+    return <EmptyState title={emptyTitle} description={emptyDescription} />;
+  }
+
+  return (
+    <Table aria-label="Entity table">
+      <TableHeader>
+        <TableRow>
+          {columns.map((column) => (
+            <TableHeaderCell key={column.id}>{column.header}</TableHeaderCell>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row, index) => (
+          <TableRow key={getRowId(row, index)}>
+            {columns.map((column) => (
+              <TableCell key={column.id}>{column.renderCell(row)}</TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/renderer/src/ui/primitives/FormDrawer.tsx
+++ b/apps/renderer/src/ui/primitives/FormDrawer.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle
+} from "@fluentui/react-components";
+
+type FormDrawerProps = {
+  open: boolean;
+  title: string;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: () => void;
+  children: ReactNode;
+  submitLabel?: string;
+};
+
+export function FormDrawer({
+  open,
+  title,
+  onOpenChange,
+  onSubmit,
+  children,
+  submitLabel = "Save"
+}: FormDrawerProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(_, data) => {
+        onOpenChange(data.open);
+      }}
+    >
+      <DialogSurface>
+        <DialogBody>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogContent>{children}</DialogContent>
+          <DialogActions>
+            <Button
+              appearance="secondary"
+              onClick={() => {
+                onOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button appearance="primary" onClick={onSubmit}>
+              {submitLabel}
+            </Button>
+          </DialogActions>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  );
+}

--- a/apps/renderer/src/ui/primitives/InlineError.tsx
+++ b/apps/renderer/src/ui/primitives/InlineError.tsx
@@ -1,0 +1,19 @@
+import { Card, Text } from "@fluentui/react-components";
+
+type InlineErrorProps = {
+  message: string;
+};
+
+export function InlineError({ message }: InlineErrorProps) {
+  return (
+    <Card
+      style={{
+        borderLeft: "4px solid #cf222e",
+        padding: "0.75rem 1rem"
+      }}
+    >
+      <Text weight="semibold">Something went wrong</Text>
+      <Text style={{ display: "block", marginTop: "0.25rem" }}>{message}</Text>
+    </Card>
+  );
+}

--- a/apps/renderer/src/ui/primitives/PageHeader.tsx
+++ b/apps/renderer/src/ui/primitives/PageHeader.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import { Text, Title2 } from "@fluentui/react-components";
+
+type PageHeaderProps = {
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+};
+
+export function PageHeader({
+  title,
+  subtitle,
+  actions
+}: PageHeaderProps) {
+  return (
+    <header
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "space-between",
+        gap: "0.75rem"
+      }}
+    >
+      <div>
+        <Title2 style={{ margin: 0 }}>{title}</Title2>
+        {subtitle ? (
+          <Text style={{ color: "#57606a", display: "block", marginTop: "0.25rem" }}>
+            {subtitle}
+          </Text>
+        ) : null}
+      </div>
+      {actions ? <div>{actions}</div> : null}
+    </header>
+  );
+}

--- a/apps/renderer/src/ui/primitives/StatusChip.tsx
+++ b/apps/renderer/src/ui/primitives/StatusChip.tsx
@@ -1,0 +1,26 @@
+import { Badge } from "@fluentui/react-components";
+
+type StatusChipTone = "info" | "success" | "warning" | "danger";
+
+type StatusChipProps = {
+  label: string;
+  tone?: StatusChipTone;
+};
+
+const toneToColor: Record<
+  StatusChipTone,
+  "brand" | "success" | "warning" | "danger"
+> = {
+  info: "brand",
+  success: "success",
+  warning: "warning",
+  danger: "danger"
+};
+
+export function StatusChip({ label, tone = "info" }: StatusChipProps) {
+  return (
+    <Badge appearance="filled" color={toneToColor[tone]}>
+      {label}
+    </Badge>
+  );
+}

--- a/apps/renderer/src/ui/primitives/__snapshots__/primitives.test.tsx.snap
+++ b/apps/renderer/src/ui/primitives/__snapshots__/primitives.test.tsx.snap
@@ -1,0 +1,32 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`design primitives > captures a stable primitive render snapshot 1`] = `
+<div
+  class="fui-FluentProvider fui-FluentProvider_r_3_ ___jdtuxv0_17k0bs4 f19n0e5 fxugw4r f1o700av fk6fouc fkhj508 figsok6 f1i3iumi"
+  dir="ltr"
+>
+  <header
+    style="display: flex; align-items: flex-start; justify-content: space-between; gap: 0.75rem;"
+  >
+    <div>
+      <span
+        class="fui-Title2 fui-Text ___15xadyy_1panhqr fk6fouc fojgt09 fcen8rp fl43uef fpgzoln f1w7gpdv f6juhto f1gl81tg f2jf649"
+        style="margin: 0px;"
+      >
+        Snapshot Header
+      </span>
+      <span
+        class="fui-Text ___c56hd20_1xy0w11 fk6fouc fkhj508 f1i3iumi figsok6 fpgzoln f1w7gpdv f6juhto f1gl81tg f2jf649"
+        style="color: rgb(87, 96, 106); display: block; margin-top: 0.25rem;"
+      >
+        Primitive baseline
+      </span>
+    </div>
+  </header>
+  <div
+    class="fui-Badge r1iycov ___18pwi1f_lps8ht0 flxk52p f1phragk"
+  >
+    Approved
+  </div>
+</div>
+`;

--- a/apps/renderer/src/ui/primitives/index.ts
+++ b/apps/renderer/src/ui/primitives/index.ts
@@ -1,0 +1,7 @@
+export { ConfirmDialog } from "./ConfirmDialog";
+export { EmptyState } from "./EmptyState";
+export { EntityTable } from "./EntityTable";
+export { FormDrawer } from "./FormDrawer";
+export { InlineError } from "./InlineError";
+export { PageHeader } from "./PageHeader";
+export { StatusChip } from "./StatusChip";

--- a/apps/renderer/src/ui/primitives/primitives.test.tsx
+++ b/apps/renderer/src/ui/primitives/primitives.test.tsx
@@ -1,0 +1,62 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { budgetItThemes } from "../theme";
+import {
+  EmptyState,
+  EntityTable,
+  InlineError,
+  PageHeader,
+  StatusChip
+} from "./index";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("design primitives", () => {
+  it("render under light, dark, and high-contrast themes", () => {
+    for (const theme of Object.values(budgetItThemes)) {
+      const { unmount } = render(
+        <FluentProvider theme={theme}>
+          <PageHeader title="Expenses" subtitle="Manage recurring costs" />
+          <StatusChip label="Planned" tone="info" />
+          <EntityTable
+            columns={[
+              { id: "name", header: "Name", renderCell: (row: { name: string }) => row.name },
+              { id: "amount", header: "Amount", renderCell: (row: { amount: string }) => row.amount }
+            ]}
+            rows={[{ name: "SaaS License", amount: "$100.00" }]}
+            getRowId={(row) => row.name}
+          />
+          <InlineError message="Unable to load expenses." />
+          <EmptyState title="No alerts" description="You're all caught up." />
+        </FluentProvider>
+      );
+
+      expect(screen.getByText("Expenses")).toBeInTheDocument();
+      expect(screen.getByText("Planned")).toBeInTheDocument();
+      expect(screen.getByText("SaaS License")).toBeInTheDocument();
+      expect(screen.getByText("Unable to load expenses.")).toBeInTheDocument();
+      expect(screen.getByText("No alerts")).toBeInTheDocument();
+      expect(screen.getByText("You're all caught up.")).toBeInTheDocument();
+
+      unmount();
+    }
+  });
+
+  it("captures a stable primitive render snapshot", () => {
+    const view = render(
+      <FluentProvider theme={budgetItThemes.light}>
+        <PageHeader title="Snapshot Header" subtitle="Primitive baseline" />
+        <StatusChip label="Approved" tone="success" />
+      </FluentProvider>
+    );
+
+    expect(view.container.firstChild).toMatchSnapshot();
+  });
+});

--- a/apps/renderer/src/ui/theme.test.ts
+++ b/apps/renderer/src/ui/theme.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { budgetItThemes } from "./theme";
+
+describe("BudgetIT theme tokens", () => {
+  it("keeps expected base typography and radius tokens", () => {
+    expect(budgetItThemes.light.fontFamilyBase).toContain("Segoe UI");
+    expect(budgetItThemes.light.borderRadiusMedium).toBe("8px");
+    expect(budgetItThemes.light.borderRadiusLarge).toBe("12px");
+  });
+
+  it("exports light, dark, and high-contrast themes", () => {
+    expect(Object.keys(budgetItThemes)).toEqual([
+      "light",
+      "dark",
+      "highContrast"
+    ]);
+  });
+});

--- a/apps/renderer/src/ui/theme.ts
+++ b/apps/renderer/src/ui/theme.ts
@@ -1,0 +1,27 @@
+import {
+  teamsHighContrastTheme,
+  webDarkTheme,
+  webLightTheme,
+  type Theme
+} from "@fluentui/react-components";
+
+function withBudgetItTokens(theme: Theme): Theme {
+  return {
+    ...theme,
+    fontFamilyBase: '"Segoe UI", Tahoma, Geneva, Verdana, sans-serif',
+    borderRadiusMedium: "8px",
+    borderRadiusLarge: "12px"
+  };
+}
+
+export const budgetItLightTheme = withBudgetItTokens(webLightTheme);
+export const budgetItDarkTheme = withBudgetItTokens(webDarkTheme);
+export const budgetItHighContrastTheme = withBudgetItTokens(
+  teamsHighContrastTheme
+);
+
+export const budgetItThemes = {
+  light: budgetItLightTheme,
+  dark: budgetItDarkTheme,
+  highContrast: budgetItHighContrastTheme
+} as const;

--- a/docs/ui-primitives.md
+++ b/docs/ui-primitives.md
@@ -1,0 +1,23 @@
+# UI Primitives
+
+This project uses Fluent UI v9 for renderer components. Reusable primitives live under `apps/renderer/src/ui/primitives`.
+
+## Usage Rules
+
+- Use `PageHeader` for every routed page heading/subheading.
+- Use `StatusChip` for discrete state labels (for example: planned, approved, snoozed, high severity).
+- Use `EntityTable` for read/list views before introducing feature-specific table behavior.
+- Use `FormDrawer` for create/edit workflows; avoid browser-native prompts.
+- Use `ConfirmDialog` for destructive or irreversible actions.
+- Use `InlineError` for recoverable panel-level failures.
+- Use `EmptyState` when a list/report has no records.
+
+## Theme
+
+Theme tokens are centralized in `apps/renderer/src/ui/theme.ts`:
+
+- `budgetItLightTheme`
+- `budgetItDarkTheme`
+- `budgetItHighContrastTheme`
+
+All renderer pages should be nested under `FluentProvider`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       "name": "@budgetit/renderer",
       "version": "0.1.0",
       "dependencies": {
+        "@fluentui/react-components": "^9.73.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.13.1"
@@ -217,7 +218,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -374,6 +374,14 @@
       ],
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -805,6 +813,11 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -1463,6 +1476,1542 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ=="
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/devtools": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/devtools/-/devtools-0.2.3.tgz",
+      "integrity": "sha512-ZTcxTvgo9CRlP7vJV62yCxdqmahHTGpSTi5QaTDgGoyQq0OyjaVZhUhXv/qdkQFOI3Sxlfmz0XGG4HaZMsDf8Q==",
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
+    },
+    "node_modules/@fluentui/keyboard-keys": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.8.tgz",
+      "integrity": "sha512-iUSJUUHAyTosnXK8O2Ilbfxma+ZyZPMua5vB028Ys96z80v+LFwntoehlFsdH3rMuPsA8GaC1RE7LMezwPBPdw==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/priority-overflow": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.3.0.tgz",
+      "integrity": "sha512-yaBC0R4e+4ZlCWDulB5S+xBrlnLwfzdg68GaarCqQO8OHjLg7Ah05xTj7PsAYcoHeEg/9vYeBwGXBpRO8+Tjqw==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-accordion": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.9.1.tgz",
+      "integrity": "sha512-gM7okIjOd3HaCMt7wTN7pnsMzXT6r/M5rVlCZbOtmkzBEJPHRoNeO+cYWS7ttvlcdpvP2nQzbFyb3Vt7HYzmWg==",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-motion": "^9.12.0",
+        "@fluentui/react-motion-components-preview": "^0.15.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-alert": {
+      "version": "9.0.0-beta.134",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.134.tgz",
+      "integrity": "sha512-uXAEL8KkjHE7SYyr2GM1H8t5pe9FYfjUcWt6odX135e9SvHwD0w8dd0wVToyvABi5PsKaRHAWY3JHsfnam4r4w==",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.10.1",
+        "@fluentui/react-button": "^9.8.2",
+        "@fluentui/react-icons": "^2.0.239",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-aria": {
+      "version": "9.17.10",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.17.10.tgz",
+      "integrity": "sha512-KqS2XcdN84XsgVG4fAESyOBfixN7zbObWfQVLNZ2gZrp2b1hPGVYfQ6J4WOO0vXMKYp0rre/QMOgDm6/srL0XQ==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-avatar": {
+      "version": "9.10.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.10.1.tgz",
+      "integrity": "sha512-rrb4v7impHzpohwWnqOemRO6WC16RbfAMwarc6TwJVC1NXC92YOlkpCDhgHqQHY51oM49fVIIPgAqi44jKZipw==",
+      "dependencies": {
+        "@fluentui/react-badge": "^9.4.15",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-popover": "^9.13.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.9.2",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-badge": {
+      "version": "9.4.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.4.15.tgz",
+      "integrity": "sha512-KgFUJHBHP76vE3EDuPg/ml7lGqxs9zJ634e+vtxn8D7ghCZ6h9P6A0WbmgsPcN6MZoBZYLzzYT3OJ6Vmu3BM8g==",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-breadcrumb": {
+      "version": "9.3.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-breadcrumb/-/react-breadcrumb-9.3.17.tgz",
+      "integrity": "sha512-POnwCFyvXabq7lNtJRslASNkrm0iRoXpnrWwh0LyBTFZRDiGDKaV18Bpk0UiuQNTUurVQiH513164XKHIP+d7Q==",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-button": "^9.8.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-link": "^9.7.4",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-button": {
+      "version": "9.8.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.8.2.tgz",
+      "integrity": "sha512-T2xBn6s6DRNH17Y+kLO+uEOaRe89Q20WP1Rs6OzC45cSpOGc+q9ogbPbYBqU7Tr1fur+Xd8LRHxdQJ3j5ufbdw==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-card": {
+      "version": "9.5.11",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.5.11.tgz",
+      "integrity": "sha512-0W3BmDER/aKx+7+ttGy+M6LO09DW7DkJlO8F0x13L1ssOVxJ0OhyhSGiCF0cJliOK1tiGPveYf6+X2xMq2MT6g==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-text": "^9.6.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-carousel": {
+      "version": "9.9.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-carousel/-/react-carousel-9.9.3.tgz",
+      "integrity": "sha512-qcVJAEg6f8ZQD3afaksZ2mo5Uyue4IJan4cUhWPLYCrkqgOS4WsvJ+7CyH3k3KLi2mR6x9Y/7OE2OwqaN4ASew==",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-button": "^9.8.2",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.9.2",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "embla-carousel": "^8.5.1",
+        "embla-carousel-autoplay": "^8.5.1",
+        "embla-carousel-fade": "^8.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-checkbox": {
+      "version": "9.5.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.5.15.tgz",
+      "integrity": "sha512-ZXvuZo8HvBLvsd74foI/p/YkxKRmruQLhleeQRMqyNKMbytFcYZ8rHmAN492tNMjmWxGIfZHv5Oh7Ds6poNmJg==",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-label": "^9.3.15",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-color-picker": {
+      "version": "9.2.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-color-picker/-/react-color-picker-9.2.15.tgz",
+      "integrity": "sha512-RMmawl7g4gUYLuTQG2QwCcR9fGC+vDD+snsBlXtObpj/cKpeDmYif46g88pYv86jeIXY1zsjINmLpELmz+uFmw==",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.3.4",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-combobox": {
+      "version": "9.16.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.16.16.tgz",
+      "integrity": "sha512-CeAC2di3xiTRB5h5XpyF+blLc6NR5VHPG+rHLRNoLjQhn9frQK3HdHGxpBVYCzx9BUU6V2IhvIcPAGgz97XHIQ==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-portal": "^9.8.11",
+        "@fluentui/react-positioning": "^9.21.0",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-components": {
+      "version": "9.73.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.73.1.tgz",
+      "integrity": "sha512-Ss323tSsAErf+dAk8rEt8aPClNRqRdK8AKyhrkz9OG6kHJbT/ST7+2rRT6e5lFl0XKc4EOAEalNrIAZIs4teSw==",
+      "dependencies": {
+        "@fluentui/react-accordion": "^9.9.1",
+        "@fluentui/react-alert": "9.0.0-beta.134",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-avatar": "^9.10.1",
+        "@fluentui/react-badge": "^9.4.15",
+        "@fluentui/react-breadcrumb": "^9.3.17",
+        "@fluentui/react-button": "^9.8.2",
+        "@fluentui/react-card": "^9.5.11",
+        "@fluentui/react-carousel": "^9.9.3",
+        "@fluentui/react-checkbox": "^9.5.15",
+        "@fluentui/react-color-picker": "^9.2.15",
+        "@fluentui/react-combobox": "^9.16.16",
+        "@fluentui/react-dialog": "^9.17.1",
+        "@fluentui/react-divider": "^9.6.2",
+        "@fluentui/react-drawer": "^9.11.4",
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-image": "^9.3.15",
+        "@fluentui/react-infobutton": "9.0.0-beta.111",
+        "@fluentui/react-infolabel": "^9.4.16",
+        "@fluentui/react-input": "^9.7.15",
+        "@fluentui/react-label": "^9.3.15",
+        "@fluentui/react-link": "^9.7.4",
+        "@fluentui/react-list": "^9.6.10",
+        "@fluentui/react-menu": "^9.21.2",
+        "@fluentui/react-message-bar": "^9.6.19",
+        "@fluentui/react-motion": "^9.12.0",
+        "@fluentui/react-nav": "^9.3.19",
+        "@fluentui/react-overflow": "^9.7.1",
+        "@fluentui/react-persona": "^9.6.1",
+        "@fluentui/react-popover": "^9.13.2",
+        "@fluentui/react-portal": "^9.8.11",
+        "@fluentui/react-positioning": "^9.21.0",
+        "@fluentui/react-progress": "^9.4.15",
+        "@fluentui/react-provider": "^9.22.15",
+        "@fluentui/react-radio": "^9.5.15",
+        "@fluentui/react-rating": "^9.3.15",
+        "@fluentui/react-search": "^9.3.15",
+        "@fluentui/react-select": "^9.4.15",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-skeleton": "^9.4.15",
+        "@fluentui/react-slider": "^9.5.15",
+        "@fluentui/react-spinbutton": "^9.5.15",
+        "@fluentui/react-spinner": "^9.7.15",
+        "@fluentui/react-swatch-picker": "^9.4.15",
+        "@fluentui/react-switch": "^9.5.4",
+        "@fluentui/react-table": "^9.19.9",
+        "@fluentui/react-tabs": "^9.11.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-tag-picker": "^9.8.0",
+        "@fluentui/react-tags": "^9.7.16",
+        "@fluentui/react-teaching-popover": "^9.6.17",
+        "@fluentui/react-text": "^9.6.15",
+        "@fluentui/react-textarea": "^9.6.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-toast": "^9.7.13",
+        "@fluentui/react-toolbar": "^9.7.3",
+        "@fluentui/react-tooltip": "^9.9.2",
+        "@fluentui/react-tree": "^9.15.11",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@fluentui/react-virtualizer": "9.0.0-alpha.111",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-context-selector": {
+      "version": "9.2.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.2.15.tgz",
+      "integrity": "sha512-QymBntFLJNZ9VfTOaBn2ApUSSSC5UuDW8ZcgPJPA+06XEFH+U9Zny2d9QAg1xYNYwIGWahWGQ+7ATOuLxtB8Jw==",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.26.2",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0",
+        "scheduler": ">=0.19.0"
+      }
+    },
+    "node_modules/@fluentui/react-dialog": {
+      "version": "9.17.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-dialog/-/react-dialog-9.17.1.tgz",
+      "integrity": "sha512-7jFcSceAqGw5nU/Fjq3s+yZJFqCY5YUI3XKKwhcqq9XwmgXvwNnh6FYCBdbcv69IXqxYsugBcCPC78C/cUDb8A==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-motion": "^9.12.0",
+        "@fluentui/react-motion-components-preview": "^0.15.1",
+        "@fluentui/react-portal": "^9.8.11",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-divider": {
+      "version": "9.6.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.6.2.tgz",
+      "integrity": "sha512-jfHlpSoJys78STe/SSjqdcn+W7QjEO1xCGiedWp/MdTBi3pH5vEeYbt2u8RU+zP32IF0Clta85KsUEEG0DYELQ==",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-drawer": {
+      "version": "9.11.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-drawer/-/react-drawer-9.11.4.tgz",
+      "integrity": "sha512-9+xPxdHj9Bfe2Oq4juBGzHRjMaMSpK/4nMysgpmne9nJ+xju8dQxBEbOCklpXOUOToY+Y6IBrhDkBXz4arbPsg==",
+      "dependencies": {
+        "@fluentui/react-dialog": "^9.17.1",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-motion": "^9.12.0",
+        "@fluentui/react-motion-components-preview": "^0.15.1",
+        "@fluentui/react-portal": "^9.8.11",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-field": {
+      "version": "9.4.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-field/-/react-field-9.4.15.tgz",
+      "integrity": "sha512-hKdl+ncnT1C3vX8zQ4LqNGUk6TiatDOAW49dr18RkONcScg2staAaDme977Iozj6+AW7AJsDfkNxq/lwHhe/pg==",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-label": "^9.3.15",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-icons": {
+      "version": "2.0.319",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.319.tgz",
+      "integrity": "sha512-4yN0ovAxlOXL5jM3ULuYu6pAwvMWm1MjojDXn5tVKDkXQwlLpXCUFwf5Vgzp5jU6jJXrENj4v64MN6w7FJjotw==",
+      "dependencies": {
+        "@griffel/react": "^1.0.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-image": {
+      "version": "9.3.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.3.15.tgz",
+      "integrity": "sha512-k8ftGUc5G3Hj5W9nOFnWEKZ1oXmoZE3EvAEdyI6Cn9R8E6zW2PZ1+cug0p6rr01JCDG8kbry1LAITcObMrlPdw==",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infobutton": {
+      "version": "9.0.0-beta.111",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infobutton/-/react-infobutton-9.0.0-beta.111.tgz",
+      "integrity": "sha512-rPQUY+FzRfXiY/0If9Bp57/ZdpBeR7u4NWcRWnfOmvkc1YVIYXagYzrAhMnNHQ2o418XNYZr5gG3aE+LLbTbJQ==",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.237",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-label": "^9.3.15",
+        "@fluentui/react-popover": "^9.13.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-infolabel": {
+      "version": "9.4.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-infolabel/-/react-infolabel-9.4.16.tgz",
+      "integrity": "sha512-/VykpbidhS0G5t2PGXmGbXXgCiOmeIxlQCqfpKZF2ZWx3fQpqriMGXBMSsVDsqTasLmUDdmz3/OWI/rp/Wy+GQ==",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-label": "^9.3.15",
+        "@fluentui/react-popover": "^9.13.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-input": {
+      "version": "9.7.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.7.15.tgz",
+      "integrity": "sha512-pzGF1mOenV03RhIy+km8GrqCfahDSLm6YG7wxpE1m2q2fY73cyLZPuMbK7Kz27oaoyUI37v4Pa4612zl12228A==",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-jsx-runtime": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-jsx-runtime/-/react-jsx-runtime-9.4.1.tgz",
+      "integrity": "sha512-ZodSm7jRa4kaLKDi+emfHFMP/IDnYwFQQAI2BdtKbVrvfwvzPRprGcnTgivnqKBT1ROvKOCY2ddz7+yZzesnNw==",
+      "dependencies": {
+        "@fluentui/react-utilities": "^9.26.2",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-label": {
+      "version": "9.3.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.3.15.tgz",
+      "integrity": "sha512-ycmaQwC4tavA8WeDfgcay1Ywu/4goHq1NOeVxkyzWTPGA7rs+tdCgdZBQZLAsBK2XFaZiHs7l+KG9r1oIRKolA==",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-link": {
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.7.4.tgz",
+      "integrity": "sha512-ILKFpo/QH1SRsLN9gopAyZT/b/xsGcdO4JxthEeuTRvpLD6gImvRplum8ySIlbTskVVzog6038bHUSYLMdN7OA==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-list": {
+      "version": "9.6.10",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-list/-/react-list-9.6.10.tgz",
+      "integrity": "sha512-NTAWYL8Z4h9N9N1b39H9xqfTyhfGkhlNTc3higpoIS/6jgEf6GMNF8iwvAyhB++hFdjBd27c+NbDl4MCwHhGiA==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-checkbox": "^9.5.15",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-menu": {
+      "version": "9.21.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.21.2.tgz",
+      "integrity": "sha512-n/GmEppa1h7FWn3iKDWFK7Oj7ww65e+FKyvQb7BtqkTRJXtcQ1eTR7upFOhoEf5AE5PN/5hL19/BDf+f+3GMqw==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-portal": "^9.8.11",
+        "@fluentui/react-positioning": "^9.21.0",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-message-bar": {
+      "version": "9.6.19",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-message-bar/-/react-message-bar-9.6.19.tgz",
+      "integrity": "sha512-NgWLLUfulxwF+WF8jFqIV3n/2bv3ZG23n9zVp+3Vejmu7XfIVJ+5dhh/l4Y/hSlKuRgNieq8nu/EMLbRLn2zKQ==",
+      "dependencies": {
+        "@fluentui/react-button": "^9.8.2",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-link": "^9.7.4",
+        "@fluentui/react-motion": "^9.12.0",
+        "@fluentui/react-motion-components-preview": "^0.15.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion": {
+      "version": "9.12.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion/-/react-motion-9.12.0.tgz",
+      "integrity": "sha512-+SBpgKLj4nXLqaulqa7LNP1bRsGO6zNesCs7ixHANFn/bGMOzET8Y3w0o522jVGZpzabEYQN7GotQy2QjT2IJg==",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-motion-components-preview": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-motion-components-preview/-/react-motion-components-preview-0.15.1.tgz",
+      "integrity": "sha512-JA1CfznIme/YD5axU3iqYCoCpBqNDbql0k6CSB6niZ2YNo5md8J+/0qHjB9B5KmA1X35+0qmSSgu4G1SOqSvfw==",
+      "dependencies": {
+        "@fluentui/react-motion": "*",
+        "@fluentui/react-utilities": "*",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-nav": {
+      "version": "9.3.19",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-nav/-/react-nav-9.3.19.tgz",
+      "integrity": "sha512-nEoHY/lMvWhiz6Udj7Hxvoz/R3WEafwQoedJqjeiLm+4vfoVaEEzGcC81jgbefnYdtRX19s90WIBkbcwWp/T4g==",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-button": "^9.8.2",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-divider": "^9.6.2",
+        "@fluentui/react-drawer": "^9.11.4",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-motion": "^9.12.0",
+        "@fluentui/react-motion-components-preview": "^0.15.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-tooltip": "^9.9.2",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-overflow": {
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.7.1.tgz",
+      "integrity": "sha512-Ml1GlcLrAUv31d9WN15WGOZv32gzDtZD5Mp1MOQ3ichDfTtxrswIch7MDzZ8hLMGf/7Y2IzBpV8iFR1XdSrGBA==",
+      "dependencies": {
+        "@fluentui/priority-overflow": "^9.3.0",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-persona": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-persona/-/react-persona-9.6.1.tgz",
+      "integrity": "sha512-KQqtvd+IVdf/XsAU8e4WcOJaHBhe6Oj83w7ZVq/7xpXzbHZsTvBPUhdcnbo9/hjSf2UYh6Duu2mnOuH8ksjfdw==",
+      "dependencies": {
+        "@fluentui/react-avatar": "^9.10.1",
+        "@fluentui/react-badge": "^9.4.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-popover": {
+      "version": "9.13.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.13.2.tgz",
+      "integrity": "sha512-FtAesk3RecprQAgmh4raFP0GICWl250itCfB3AUb75b+1onPfTsZcdhfOiumRmU6smQy0N9w7HG2ZxHgl5jvSA==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-portal": "^9.8.11",
+        "@fluentui/react-positioning": "^9.21.0",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-portal": {
+      "version": "9.8.11",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.8.11.tgz",
+      "integrity": "sha512-2eg4MdW7e2UGRYWPg05GCytAjWYNd55YOP9+iUDINoQwwto9oeFTtZRyn08HYw37cSNqoH24qGz/VBctzTkqDA==",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-positioning": {
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.21.0.tgz",
+      "integrity": "sha512-1hkzaEQszS3ZTAIL8m/tV6c8sFaLBjp0EFo1UO+RvF/JmIrg64RagsIcc5k/SZ0d6oBp04zJlNN8gNPnxFJUpQ==",
+      "dependencies": {
+        "@floating-ui/devtools": "^0.2.3",
+        "@floating-ui/dom": "^1.6.12",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-progress": {
+      "version": "9.4.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-progress/-/react-progress-9.4.15.tgz",
+      "integrity": "sha512-U2dqtEtov7FoeIGSAEqdFV2O2pjx3gFzbCWpPkpuLCshOSGjCPPeLV3iiTGP1WFrGCcpwFoz5O2YmsnA3wf4oQ==",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-provider": {
+      "version": "9.22.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.22.15.tgz",
+      "integrity": "sha512-a+ImgL9DOlylDM4UYPnxQTA3yXxbVj+O0iNEyTZ6fMzdMsHzpALU4GAq6tOyW4L7RaQtRBmNpVfwTCEKpqaTJQ==",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/core": "^1.16.0",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-radio": {
+      "version": "9.5.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.5.15.tgz",
+      "integrity": "sha512-47Zhe1Ec02QXczoPNLTFwcvCQFGoXInEiXhsQYF0tD+XAX6Q675j/z6gsIItc8V+avvD0IITsDPpqQ09wfNYkQ==",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-label": "^9.3.15",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-rating": {
+      "version": "9.3.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-rating/-/react-rating-9.3.15.tgz",
+      "integrity": "sha512-MH/Jgoco8p+haf1d5Gi+d5VCjwd0qE6y/uP0YJsB9m11+DFnDxgKhzJKIiIzs3yzB2M4bMM8z9SqEHzQGCQEPg==",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-search": {
+      "version": "9.3.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-search/-/react-search-9.3.15.tgz",
+      "integrity": "sha512-xm9YveJM4aXAn/XjG3GMHpXxLO53Nz2mmuJpc80WXaYqQwesGSS0YfMSTbjM04RkvMsjmQM/dwWcudV9JQ0//g==",
+      "dependencies": {
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-input": "^9.7.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-select": {
+      "version": "9.4.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.4.15.tgz",
+      "integrity": "sha512-NWoDzf3H7mu8fXBCR3YIlumMb7lDElsbmcCSIlUz70n2cPTNXcNEQm4ERWiGAmxf8xoAfgfDWc5rYnRWAFi2fA==",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-shared-contexts": {
+      "version": "9.26.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.26.2.tgz",
+      "integrity": "sha512-upKXkwlIp5oIhELr4clAZXQkuCd4GDXM6GZEz8BOmRO+PnxyqmycCXvxDxsmi6XN+0vkGM4joiIgkB14o/FctQ==",
+      "dependencies": {
+        "@fluentui/react-theme": "^9.2.1",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-skeleton": {
+      "version": "9.4.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-skeleton/-/react-skeleton-9.4.15.tgz",
+      "integrity": "sha512-QUVxZ5pYbIprCY1G5sJYDGvuvM1TNFl3vPkME8r/nD7pKXwxaZYJoob2L0DQ9OdnOeHgO8yTOgOgZEU+Km89dA==",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-slider": {
+      "version": "9.5.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.5.15.tgz",
+      "integrity": "sha512-lFDkyYYAUUGwbg1UJqjsuQ2tQUBFjxzv2Bpyr1StyAoS91q8skTUDyZxamJTJ0K6Ox/nhkfg+Wzz2aVg9kkF4Q==",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinbutton": {
+      "version": "9.5.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.5.15.tgz",
+      "integrity": "sha512-0NNfaXm8TJWHlillg6FPgJ1Ph7iO9ez+Gz4TSFYm1u+zF8RNsSGoplCf40U6gcKX8GkAHBwQ5vBZUbBK7syDng==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-spinner": {
+      "version": "9.7.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.7.15.tgz",
+      "integrity": "sha512-ZMJ7y08yvVXL9HuiMLLCy1cRn8plR9A4mL57CM2/otaXVWQbOwRaFD0/+Dx3u9A8sEtdYLo6O9gJIjU8fZGaYw==",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-label": "^9.3.15",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-swatch-picker": {
+      "version": "9.4.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-swatch-picker/-/react-swatch-picker-9.4.15.tgz",
+      "integrity": "sha512-jeYSEDwLbQAW/UoTP15EZpVm2Z+UpPSjkgJaKk73UxX1+rD/JIzpxrN3FfEfkn3/uTZUQkd/SE4NQrilu1OMZQ==",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-switch": {
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.5.4.tgz",
+      "integrity": "sha512-h5EosIApoz4bwgX6yKzKSf2ewTI21ghRZwyOhWOBmMc3g6Kt4kJU7gOyOtiRkoBcTE6tCpSKcrkhqeTM8G08IA==",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-label": "^9.3.15",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-table": {
+      "version": "9.19.9",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-table/-/react-table-9.19.9.tgz",
+      "integrity": "sha512-CatOI+zE1/xGfhxSlYPklLwVgUQqvOhTNaqL3l8Wpe5omre/v+D5nQdTA9x9xKD+c2J4IZl3r4btOttwYJsDtA==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-avatar": "^9.10.1",
+        "@fluentui/react-checkbox": "^9.5.15",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-radio": "^9.5.15",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabs": {
+      "version": "9.11.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.11.2.tgz",
+      "integrity": "sha512-zmWzySlPM9EwHJNW0/JhyxBCqBvmfZIj1OZLdRDpbPDsKjhO0aGZV6WjLHFYJmq58kbN0wHKUbxc7LfafHHUwA==",
+      "dependencies": {
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tabster": {
+      "version": "9.26.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.26.13.tgz",
+      "integrity": "sha512-uOuJj7jn1ME52Vc685/Ielf6srK/sfFQA5zBIbXIvy2Eisfp7R1RmJe2sXWoszz/Fu/XDkPwdM/GLv23N3vrvQ==",
+      "dependencies": {
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "keyborg": "^2.6.0",
+        "tabster": "^8.5.5"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tag-picker": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tag-picker/-/react-tag-picker-9.8.0.tgz",
+      "integrity": "sha512-LQk+BFfKHYqVFCgIPbMtcQFpceeeF2Dk2HLTLnzlgt9AjavqevpWUgbjvjOHLMJ5rkn8y5un/bnD0iXiRVutgQ==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-combobox": "^9.16.16",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-portal": "^9.8.11",
+        "@fluentui/react-positioning": "^9.21.0",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-tags": "^9.7.16",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tags": {
+      "version": "9.7.16",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tags/-/react-tags-9.7.16.tgz",
+      "integrity": "sha512-EgxFGG7nFtBJq3EbQyzhhxtZSSFckcHPeC9fiT9hY3GhfDwr/SYwh3jt4FiW/MY3hRjaU9EeRjkGNaVVQpA5tw==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-avatar": "^9.10.1",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-teaching-popover": {
+      "version": "9.6.17",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-teaching-popover/-/react-teaching-popover-9.6.17.tgz",
+      "integrity": "sha512-1edb0zk6AuK9OrUVmFOIbZb0yzuMpcSmasfXDxdMiNP/q/44iD/4Ab0LfGYChaLDHk3Vx9x0MMrzD9nX+ImRUQ==",
+      "dependencies": {
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-button": "^9.8.2",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-popover": "^9.13.2",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0 <20.0.0",
+        "@types/react-dom": ">=16.8.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-text": {
+      "version": "9.6.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.6.15.tgz",
+      "integrity": "sha512-YB1azhq8MGfnYTGlEAX1mzcFZ6CvqkkaxaCogU4TM9BtPgQ1YUAxE01RMenl8VVi8W9hNbJKkuc8R8GzYwzT4Q==",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-textarea": {
+      "version": "9.6.15",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.6.15.tgz",
+      "integrity": "sha512-yGYW3d+t21qJXlVsbAHz07RR/YxVw5b56483nFAbqGP3RpPG8ert8q9Ci2mldI9LpjYTG5deXUHqfcVGJ7qDAg==",
+      "dependencies": {
+        "@fluentui/react-field": "^9.4.15",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-theme": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.2.1.tgz",
+      "integrity": "sha512-lJxfz7LmmglFz+c9C41qmMqaRRZZUPtPPl9DWQ79vH+JwZd4dkN7eA78OTRwcGCOTPEKoLTX72R+EFaWEDlX+w==",
+      "dependencies": {
+        "@fluentui/tokens": "1.0.0-alpha.23",
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@fluentui/react-toast": {
+      "version": "9.7.13",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toast/-/react-toast-9.7.13.tgz",
+      "integrity": "sha512-mUJExTNcaeJkVugiMObfHb313y3Qntdzmhbf2R6x0q9lVp7oleYi8KLxmZRHD713q0KpAI4o0ZjIbo0c+9EvzQ==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-motion": "^9.12.0",
+        "@fluentui/react-motion-components-preview": "^0.15.1",
+        "@fluentui/react-portal": "^9.8.11",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-toolbar": {
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.7.3.tgz",
+      "integrity": "sha512-h9mXLrQ55SFd2YXJXQOtpC+MJ3SckyGB5lWqFkQxqExFZkkeCL1u1bRf2/YFjNj8gbivVMwKmozzWeccexPeyQ==",
+      "dependencies": {
+        "@fluentui/react-button": "^9.8.2",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-divider": "^9.6.2",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-radio": "^9.5.15",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tooltip": {
+      "version": "9.9.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.9.2.tgz",
+      "integrity": "sha512-LcYQyOqUxAq/FZX4BzMMVA2aX5wkyEZGzoIguehedZClIwQFZT/DeQ2RPNIXOfpmDTs0hcb4MFb3gknFPHigBA==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-portal": "^9.8.11",
+        "@fluentui/react-positioning": "^9.21.0",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-tree": {
+      "version": "9.15.11",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-tree/-/react-tree-9.15.11.tgz",
+      "integrity": "sha512-bQBa+MTAr04LIRVHsRiaG3q4DPVdyMx4VvnpiKT09eGTsVfNysXi+t65qdGfUMW7+Ppp4RlXZ6hWI3kdbWRdyw==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-aria": "^9.17.10",
+        "@fluentui/react-avatar": "^9.10.1",
+        "@fluentui/react-button": "^9.8.2",
+        "@fluentui/react-checkbox": "^9.5.15",
+        "@fluentui/react-context-selector": "^9.2.15",
+        "@fluentui/react-icons": "^2.0.245",
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-motion": "^9.12.0",
+        "@fluentui/react-motion-components-preview": "^0.15.1",
+        "@fluentui/react-radio": "^9.5.15",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-tabster": "^9.26.13",
+        "@fluentui/react-theme": "^9.2.1",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-utilities": {
+      "version": "9.26.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.26.2.tgz",
+      "integrity": "sha512-Yp2GGNoWifj8Z/VVir4HyRumRsqXnLJd4IP/Y70vEm9ruAvyqUvfn+1lQUuA+k/Reqw8GI+Ix7FTo3rogixZBg==",
+      "dependencies": {
+        "@fluentui/keyboard-keys": "^9.0.8",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/react-virtualizer": {
+      "version": "9.0.0-alpha.111",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-virtualizer/-/react-virtualizer-9.0.0-alpha.111.tgz",
+      "integrity": "sha512-yku++0779Ve1RNz6y/HWjlXKd2x1wCSbWMydT2IdCICBVwolXjPYMpkqqZUSjbJ0N9gl6BfsCBpU9Dfe2bR8Zg==",
+      "dependencies": {
+        "@fluentui/react-jsx-runtime": "^9.4.1",
+        "@fluentui/react-shared-contexts": "^9.26.2",
+        "@fluentui/react-utilities": "^9.26.2",
+        "@griffel/react": "^1.5.32",
+        "@swc/helpers": "^0.5.1"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.14.0 <20.0.0",
+        "@types/react-dom": ">=16.9.0 <20.0.0",
+        "react": ">=16.14.0 <20.0.0",
+        "react-dom": ">=16.14.0 <20.0.0"
+      }
+    },
+    "node_modules/@fluentui/tokens": {
+      "version": "1.0.0-alpha.23",
+      "resolved": "https://registry.npmjs.org/@fluentui/tokens/-/tokens-1.0.0-alpha.23.tgz",
+      "integrity": "sha512-uxrzF9Z+J10naP0pGS7zPmzSkspSS+3OJDmYIK3o1nkntQrgBXq3dBob4xSlTDm5aOQ0kw6EvB9wQgtlyy4eKQ==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.1"
+      }
+    },
+    "node_modules/@griffel/core": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.19.2.tgz",
+      "integrity": "sha512-WkB/QQkjy9dE4vrNYGhQvRRUHFkYVOuaznVOMNTDT4pS9aTJ9XPrMTXXlkpcwaf0D3vNKoerj4zAwnU2lBzbOg==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.0",
+        "@griffel/style-types": "^1.3.0",
+        "csstype": "^3.1.3",
+        "rtl-css-js": "^1.16.1",
+        "stylis": "^4.2.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@griffel/react": {
+      "version": "1.5.32",
+      "resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.5.32.tgz",
+      "integrity": "sha512-jN3SmSwAUcWFUQuQ9jlhqZ5ELtKY21foaUR0q1mJtiAeSErVgjkpKJyMLRYpvaFGWrDql0Uz23nXUogXbsS2wQ==",
+      "dependencies": {
+        "@griffel/core": "^1.19.2",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@griffel/style-types": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@griffel/style-types/-/style-types-1.3.0.tgz",
+      "integrity": "sha512-bHwD3sUE84Xwv4dH011gOKe1jul77M1S6ZFN9Tnq8pvZ48UMdY//vtES6fv7GRS5wXYT4iqxQPBluAiYAfkpmw==",
+      "dependencies": {
+        "csstype": "^3.1.3"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2078,6 +3627,14 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.19.tgz",
+      "integrity": "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -2267,7 +3824,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2276,7 +3832,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3793,8 +5348,7 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -4483,6 +6037,27 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA=="
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
+    },
+    "node_modules/embla-carousel-fade": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-fade/-/embla-carousel-fade-8.6.0.tgz",
+      "integrity": "sha512-qaYsx5mwCz72ZrjlsXgs1nKejSrW+UhkbOMwLgfRT7w2LtdEB03nPRI06GHuHv5ac2USvbEiX2/nAHctcDwvpg==",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -5942,6 +7517,11 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/keyborg": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/keyborg/-/keyborg-2.6.0.tgz",
+      "integrity": "sha512-o5kvLbuTF+o326CMVYpjlaykxqYP9DphFQZ2ZpgrvBouyvOxyEB7oqe8nOLFpiV5VCtz0D3pt8gXQYWpLpBnmA=="
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7381,6 +8961,14 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -7805,6 +9393,11 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true
     },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ=="
+    },
     "node_modules/sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -7833,6 +9426,30 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/tabster": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/tabster/-/tabster-8.7.0.tgz",
+      "integrity": "sha512-AKYquti8AdWzuqJdQo4LUMQDZrHoYQy6V+8yUq2PmgLZV10EaB+8BD0nWOfC/3TBp4mPNg4fbHkz6SFtkr0PpA==",
+      "dependencies": {
+        "keyborg": "2.6.0",
+        "tslib": "^2.8.1"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.53.3"
+      }
+    },
+    "node_modules/tabster/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/tar": {
       "version": "7.5.9",
@@ -8110,6 +9727,11 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -8255,6 +9877,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/utf8-byte-length": {


### PR DESCRIPTION
## Summary
- adopt Fluent UI v9 as the shared renderer component system
- add centralized light/dark/high-contrast theme tokens in src/ui/theme.ts
- add reusable UI primitives (PageHeader, StatusChip, EntityTable, FormDrawer, ConfirmDialog, InlineError, EmptyState)
- migrate app shell controls and placeholder pages to Fluent components
- document usage patterns in docs/ui-primitives.md

## Test Plan
- npm run lint --workspace @budgetit/renderer
- npm run typecheck --workspace @budgetit/renderer
- npm run test --workspace @budgetit/renderer
- npm run build --workspace @budgetit/renderer

Closes #58