### PR TITLE
[U3] Dashboard redesign with KPI cards, charts, stale CTA, and export menu

### DIFF
--- a/apps/renderer/src/app/app-shell.test.tsx
+++ b/apps/renderer/src/app/app-shell.test.tsx
@@ -1,20 +1,24 @@
 /* @vitest-environment jsdom */
 
 import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it } from "vitest";
 
+import { budgetItLightTheme } from "../ui/theme";
 import { AppShell } from "./AppShell";
 import { AppRoutes } from "./routes";
 
 function renderAt(path: string) {
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <AppShell>
-        <AppRoutes />
-      </AppShell>
-    </MemoryRouter>
+    <FluentProvider theme={budgetItLightTheme}>
+      <MemoryRouter initialEntries={[path]}>
+        <AppShell>
+          <AppRoutes />
+        </AppShell>
+      </MemoryRouter>
+    </FluentProvider>
   );
 }
 
@@ -28,9 +32,7 @@ describe("AppShell", () => {
 
     expect(screen.getByLabelText("Primary navigation")).toBeInTheDocument();
     expect(screen.getByTestId("page-title")).toHaveTextContent("Dashboard");
-    expect(
-      screen.getByText("Dashboard workspace is being upgraded")
-    ).toBeInTheDocument();
+    expect(screen.getByText("Loading dashboard...")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Alerts" })).toBeInTheDocument();
   });
 

--- a/apps/renderer/src/features/dashboard/DashboardPage.css
+++ b/apps/renderer/src/features/dashboard/DashboardPage.css
@@ -1,0 +1,128 @@
+.dashboard-page {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.dashboard-page--loading {
+  min-height: 40vh;
+  place-content: center;
+}
+
+.dashboard-page__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dashboard-page__stale-card {
+  border-left: 4px solid #d97706;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.dashboard-page__export-list {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.dashboard-kpis {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dashboard-kpi-card {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.dashboard-chart-card {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.dashboard-chart {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.dashboard-chart__row {
+  display: grid;
+  grid-template-columns: 5.5rem minmax(0, 1fr) 5rem;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dashboard-chart__bar-group {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.dashboard-chart__bar-track {
+  height: 0.45rem;
+  border-radius: 999px;
+  background: #d1d5db;
+  overflow: hidden;
+}
+
+.dashboard-chart__bar {
+  height: 100%;
+  border-radius: inherit;
+}
+
+.dashboard-chart__bar--forecast {
+  background: #6366f1;
+}
+
+.dashboard-chart__bar--actual {
+  background: #0ea5e9;
+}
+
+.dashboard-chart__bar--variance-up {
+  background: #d97706;
+}
+
+.dashboard-chart__bar--variance-down {
+  background: #16a34a;
+}
+
+.dashboard-chart__bar--renewal {
+  background: #ec4899;
+}
+
+.dashboard-chart__label,
+.dashboard-chart__value {
+  font-size: 0.85rem;
+}
+
+.dashboard-narratives {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+@media (max-width: 1380px) {
+  .dashboard-kpis {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dashboard-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 1080px) {
+  .dashboard-kpis,
+  .dashboard-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/apps/renderer/src/features/dashboard/DashboardPage.test.tsx
+++ b/apps/renderer/src/features/dashboard/DashboardPage.test.tsx
@@ -1,0 +1,169 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DashboardDataset } from "../../reporting";
+import { AppShell } from "../../app/AppShell";
+import { AppRoutes } from "../../app/routes";
+import { exportReport, queryReport } from "../../lib/ipcClient";
+import { budgetItLightTheme } from "../../ui/theme";
+import { DashboardPage } from "./DashboardPage";
+
+vi.mock("../../lib/ipcClient", () => ({
+  queryReport: vi.fn(),
+  exportReport: vi.fn()
+}));
+
+const datasetFixture: DashboardDataset = {
+  scenarioId: "baseline",
+  staleForecast: true,
+  spendTrend: [
+    { month: "2026-01", forecastMinor: 12000, actualMinor: 10000 },
+    { month: "2026-02", forecastMinor: 14000, actualMinor: 15000 }
+  ],
+  variance: [
+    {
+      month: "2026-01",
+      forecastMinor: 12000,
+      actualMinor: 10000,
+      varianceMinor: -2000,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    },
+    {
+      month: "2026-02",
+      forecastMinor: 14000,
+      actualMinor: 15000,
+      varianceMinor: 1000,
+      unmatchedActualMinor: 1000,
+      unmatchedCount: 1
+    }
+  ],
+  renewals: [{ month: "2026-06", count: 2 }],
+  growth: [
+    { month: "2026-01", forecastMinor: 12000, growthPct: null },
+    { month: "2026-02", forecastMinor: 14000, growthPct: 16.7 }
+  ],
+  taggingCompleteness: {
+    totalExpenseLines: 4,
+    taggedExpenseLines: 3,
+    completenessRatio: 0.75
+  },
+  replacementStatus: {
+    totalPlans: 3,
+    replacementRequiredOpen: 1,
+    byStatus: [{ status: "draft", count: 3 }]
+  },
+  narrativeBlocks: [{ id: "summary", title: "Summary", body: "Narrative text" }]
+};
+
+const queryReportMock = vi.mocked(queryReport);
+const exportReportMock = vi.mocked(exportReport);
+
+function renderDashboardPage() {
+  return render(
+    <FluentProvider theme={budgetItLightTheme}>
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    </FluentProvider>
+  );
+}
+
+describe("DashboardPage", () => {
+  beforeEach(() => {
+    queryReportMock.mockReset();
+    exportReportMock.mockReset();
+    queryReportMock.mockResolvedValue(datasetFixture);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders KPI cards and chart sections from dashboard dataset", async () => {
+    renderDashboardPage();
+
+    await screen.findByText("Forecast");
+    expect(queryReportMock).toHaveBeenCalledWith({
+      query: "dashboard.summary",
+      scenarioId: "baseline"
+    });
+
+    expect(screen.getByText("Spend Trend")).toBeInTheDocument();
+    expect(screen.getAllByText("Variance").length).toBeGreaterThan(0);
+    expect(screen.getByText("Renewals Timeline")).toBeInTheDocument();
+    expect(screen.getByText("Tagging Completeness")).toBeInTheDocument();
+  });
+
+  it("shows stale warning and allows re-materialize refresh entry point", async () => {
+    renderDashboardPage();
+
+    await screen.findByTestId("stale-forecast-banner");
+    fireEvent.click(screen.getByRole("button", { name: "Re-materialize" }));
+
+    await waitFor(() => {
+      expect(queryReportMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("exports selected format and displays output path", async () => {
+    exportReportMock.mockResolvedValue({
+      files: { csv: "C:\\exports\\dashboard.csv" }
+    });
+
+    renderDashboardPage();
+    await screen.findByText("Forecast");
+
+    fireEvent.click(screen.getByRole("button", { name: "Export" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Export CSV" }));
+
+    await waitFor(() => {
+      expect(exportReportMock).toHaveBeenCalledWith({
+        scenarioId: "baseline",
+        formats: ["csv"]
+      });
+    });
+    expect(await screen.findByText(/C:\\exports\\dashboard\.csv/i)).toBeInTheDocument();
+  });
+
+  it("renders dashboard as default app route and completes one export flow", async () => {
+    exportReportMock.mockResolvedValue({
+      files: { html: "C:\\exports\\dashboard.html" }
+    });
+
+    render(
+      <FluentProvider theme={budgetItLightTheme}>
+        <MemoryRouter initialEntries={["/"]}>
+          <AppShell>
+            <AppRoutes />
+          </AppShell>
+        </MemoryRouter>
+      </FluentProvider>
+    );
+
+    await screen.findByText("Forecast");
+    expect(screen.getByTestId("page-title")).toHaveTextContent("Dashboard");
+
+    fireEvent.click(screen.getByRole("button", { name: "Export" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Export HTML" }));
+
+    await waitFor(() => {
+      expect(exportReportMock).toHaveBeenCalledWith({
+        scenarioId: "baseline",
+        formats: ["html"]
+      });
+    });
+    expect(await screen.findByText(/C:\\exports\\dashboard\.html/i)).toBeInTheDocument();
+  });
+});

--- a/apps/renderer/src/features/dashboard/DashboardPage.tsx
+++ b/apps/renderer/src/features/dashboard/DashboardPage.tsx
@@ -1,11 +1,351 @@
-import { FeaturePlaceholderPage } from "../common/FeaturePlaceholderPage";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Spinner,
+  Text,
+  Title3
+} from "@fluentui/react-components";
 
-export function DashboardPage() {
-  return (
-    <FeaturePlaceholderPage
-      title="Dashboard"
-      description="Dashboard redesign will land in U3 with KPI cards, trend charts, renewals, stale indicators, and export actions."
-    />
-  );
+import type { DashboardDataset } from "../../reporting";
+import { exportReport, queryReport } from "../../lib/ipcClient";
+import { EmptyState, InlineError, PageHeader } from "../../ui/primitives";
+import {
+  buildDashboardKpiMetrics,
+  mapDashboardStaleState
+} from "./dashboard-model";
+import "./DashboardPage.css";
+
+type ExportFormat = "html" | "pdf" | "excel" | "csv" | "png";
+
+const DASHBOARD_SCENARIO_ID = "baseline";
+const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD"
+});
+
+const EXPORT_FORMAT_OPTIONS: Array<{ format: ExportFormat; label: string }> = [
+  { format: "html", label: "Export HTML" },
+  { format: "pdf", label: "Export PDF" },
+  { format: "excel", label: "Export Excel" },
+  { format: "csv", label: "Export CSV" },
+  { format: "png", label: "Export PNG" }
+];
+
+function formatUsd(minor: number): string {
+  return CURRENCY_FORMATTER.format(minor / 100);
 }
 
+function toPercent(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+function barWidth(value: number, max: number): string {
+  if (max <= 0) {
+    return "0%";
+  }
+  return `${Math.max((value / max) * 100, 2)}%`;
+}
+
+export function DashboardPage() {
+  const [dataset, setDataset] = useState<DashboardDataset | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshMessage, setRefreshMessage] = useState<string | null>(null);
+  const [rematerializing, setRematerializing] = useState(false);
+  const [exportingFormat, setExportingFormat] = useState<ExportFormat | null>(null);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [exportFiles, setExportFiles] = useState<
+    Partial<Record<ExportFormat, string>>
+  >({});
+
+  const kpis = useMemo(
+    () => (dataset ? buildDashboardKpiMetrics(dataset) : null),
+    [dataset]
+  );
+  const staleState = useMemo(
+    () => (dataset ? mapDashboardStaleState(dataset) : { isStale: false, message: null }),
+    [dataset]
+  );
+  const maxSpendMinor = useMemo(() => {
+    if (!dataset || dataset.spendTrend.length === 0) {
+      return 0;
+    }
+    return Math.max(...dataset.spendTrend.map((row) => Math.max(row.forecastMinor, row.actualMinor)));
+  }, [dataset]);
+  const maxRenewalCount = useMemo(() => {
+    if (!dataset || dataset.renewals.length === 0) {
+      return 0;
+    }
+    return Math.max(...dataset.renewals.map((row) => row.count));
+  }, [dataset]);
+  const maxVarianceMinor = useMemo(() => {
+    if (!dataset || dataset.variance.length === 0) {
+      return 0;
+    }
+    return Math.max(...dataset.variance.map((row) => Math.abs(row.varianceMinor)));
+  }, [dataset]);
+
+  async function loadDashboard(rematerialize = false): Promise<void> {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = (await queryReport({
+        query: "dashboard.summary",
+        scenarioId: DASHBOARD_SCENARIO_ID
+      })) as DashboardDataset;
+      setDataset(next);
+      setRefreshMessage(
+        rematerialize
+          ? "Re-materialize action requested and dashboard data refreshed."
+          : "Dashboard data refreshed."
+      );
+    } catch (nextError) {
+      const detail = nextError instanceof Error ? nextError.message : String(nextError);
+      setError(`Failed to load dashboard: ${detail}`);
+    } finally {
+      setLoading(false);
+      setRematerializing(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadDashboard();
+  }, []);
+
+  async function handleRematerialize(): Promise<void> {
+    setRematerializing(true);
+    await loadDashboard(true);
+  }
+
+  async function handleExport(format: ExportFormat): Promise<void> {
+    setExportingFormat(format);
+    setExportError(null);
+    try {
+      const result = await exportReport({
+        scenarioId: DASHBOARD_SCENARIO_ID,
+        formats: [format]
+      });
+      setExportFiles(result.files);
+    } catch (nextError) {
+      const detail = nextError instanceof Error ? nextError.message : String(nextError);
+      setExportError(`Export failed for ${format.toUpperCase()}: ${detail}`);
+    } finally {
+      setExportingFormat(null);
+    }
+  }
+
+  if (loading && !dataset) {
+    return (
+      <section className="dashboard-page dashboard-page--loading" aria-live="polite">
+        <Spinner label="Loading dashboard..." />
+      </section>
+    );
+  }
+
+  return (
+    <section className="dashboard-page" aria-live="polite">
+      <PageHeader
+        title="Dashboard"
+        subtitle="Decision-ready view for forecast, actuals, renewals, and replacement readiness."
+        actions={
+          <div className="dashboard-page__actions">
+            <Button appearance="secondary" onClick={() => void loadDashboard()}>
+              Refresh
+            </Button>
+            <Menu>
+              <MenuTrigger disableButtonEnhancement>
+                <Button appearance="primary" disabled={exportingFormat !== null}>
+                  {exportingFormat ? `Exporting ${exportingFormat.toUpperCase()}...` : "Export"}
+                </Button>
+              </MenuTrigger>
+              <MenuPopover>
+                <MenuList>
+                  {EXPORT_FORMAT_OPTIONS.map((option) => (
+                    <MenuItem
+                      key={option.format}
+                      disabled={exportingFormat !== null}
+                      onClick={() => {
+                        void handleExport(option.format);
+                      }}
+                    >
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          </div>
+        }
+      />
+
+      {staleState.isStale ? (
+        <Card className="dashboard-page__stale-card" data-testid="stale-forecast-banner">
+          <Text weight="semibold">Forecast freshness warning</Text>
+          <Text>{staleState.message}</Text>
+          <Button
+            appearance="secondary"
+            disabled={rematerializing}
+            onClick={() => void handleRematerialize()}
+          >
+            {rematerializing ? "Re-materializing..." : "Re-materialize"}
+          </Button>
+        </Card>
+      ) : null}
+
+      {error ? <InlineError message={error} /> : null}
+      {refreshMessage ? <Text>{refreshMessage}</Text> : null}
+      {exportError ? <InlineError message={exportError} /> : null}
+
+      {Object.keys(exportFiles).length > 0 ? (
+        <Card data-testid="export-result-card">
+          <Text weight="semibold">Export completed</Text>
+          <ul className="dashboard-page__export-list">
+            {Object.entries(exportFiles).map(([format, filePath]) => (
+              <li key={format}>
+                <Text>
+                  {format.toUpperCase()}: {filePath}
+                </Text>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      ) : null}
+
+      {!dataset || !kpis ? (
+        <EmptyState
+          title="No dashboard data available"
+          description="Import or create records to populate dashboard insights."
+        />
+      ) : (
+        <>
+          <section className="dashboard-kpis">
+            <Card className="dashboard-kpi-card">
+              <Text>Forecast</Text>
+              <Title3>{formatUsd(kpis.forecastMinor)}</Title3>
+            </Card>
+            <Card className="dashboard-kpi-card">
+              <Text>Actual</Text>
+              <Title3>{formatUsd(kpis.actualMinor)}</Title3>
+            </Card>
+            <Card className="dashboard-kpi-card">
+              <Text>Variance</Text>
+              <Title3>{formatUsd(kpis.varianceMinor)}</Title3>
+              <Badge
+                appearance="filled"
+                color={kpis.varianceMinor > 0 ? "warning" : "success"}
+              >
+                {kpis.varianceMinor > 0 ? "Above Forecast" : "Within Forecast"}
+              </Badge>
+            </Card>
+            <Card className="dashboard-kpi-card">
+              <Text>Renewals (Upcoming)</Text>
+              <Title3>{kpis.renewalCount}</Title3>
+            </Card>
+            <Card className="dashboard-kpi-card">
+              <Text>Tagging Completeness</Text>
+              <Title3>{toPercent(kpis.taggingCompletenessPct)}</Title3>
+            </Card>
+            <Card className="dashboard-kpi-card">
+              <Text>Replacement Required</Text>
+              <Title3>{kpis.replacementRequiredOpen}</Title3>
+            </Card>
+          </section>
+
+          <section className="dashboard-grid">
+            <Card className="dashboard-chart-card">
+              <Title3>Spend Trend</Title3>
+              <div className="dashboard-chart">
+                {dataset.spendTrend.map((row) => (
+                  <div className="dashboard-chart__row" key={row.month}>
+                    <Text className="dashboard-chart__label">{row.month}</Text>
+                    <div className="dashboard-chart__bar-group">
+                      <div className="dashboard-chart__bar-track">
+                        <div
+                          className="dashboard-chart__bar dashboard-chart__bar--forecast"
+                          style={{ width: barWidth(row.forecastMinor, maxSpendMinor) }}
+                          title={`Forecast ${formatUsd(row.forecastMinor)}`}
+                        />
+                      </div>
+                      <div className="dashboard-chart__bar-track">
+                        <div
+                          className="dashboard-chart__bar dashboard-chart__bar--actual"
+                          style={{ width: barWidth(row.actualMinor, maxSpendMinor) }}
+                          title={`Actual ${formatUsd(row.actualMinor)}`}
+                        />
+                      </div>
+                    </div>
+                    <Text className="dashboard-chart__value">{formatUsd(row.actualMinor)}</Text>
+                  </div>
+                ))}
+              </div>
+            </Card>
+
+            <Card className="dashboard-chart-card">
+              <Title3>Variance</Title3>
+              <div className="dashboard-chart">
+                {dataset.variance.map((row) => (
+                  <div className="dashboard-chart__row" key={row.month}>
+                    <Text className="dashboard-chart__label">{row.month}</Text>
+                    <div className="dashboard-chart__bar-track">
+                      <div
+                        className={
+                          row.varianceMinor >= 0
+                            ? "dashboard-chart__bar dashboard-chart__bar--variance-up"
+                            : "dashboard-chart__bar dashboard-chart__bar--variance-down"
+                        }
+                        style={{
+                          width: barWidth(Math.abs(row.varianceMinor), maxVarianceMinor)
+                        }}
+                        title={`Variance ${formatUsd(row.varianceMinor)}`}
+                      />
+                    </div>
+                    <Text className="dashboard-chart__value">{formatUsd(row.varianceMinor)}</Text>
+                  </div>
+                ))}
+              </div>
+            </Card>
+
+            <Card className="dashboard-chart-card">
+              <Title3>Renewals Timeline</Title3>
+              <div className="dashboard-chart">
+                {dataset.renewals.length === 0 ? (
+                  <Text>No renewals scheduled.</Text>
+                ) : (
+                  dataset.renewals.map((row) => (
+                    <div className="dashboard-chart__row" key={row.month}>
+                      <Text className="dashboard-chart__label">{row.month}</Text>
+                      <div className="dashboard-chart__bar-track">
+                        <div
+                          className="dashboard-chart__bar dashboard-chart__bar--renewal"
+                          style={{ width: barWidth(row.count, maxRenewalCount) }}
+                          title={`Renewals ${row.count}`}
+                        />
+                      </div>
+                      <Text className="dashboard-chart__value">{row.count}</Text>
+                    </div>
+                  ))
+                )}
+              </div>
+            </Card>
+          </section>
+
+          <section className="dashboard-narratives">
+            {dataset.narrativeBlocks.map((block) => (
+              <Card key={block.id}>
+                <Text weight="semibold">{block.title}</Text>
+                <Text>{block.body}</Text>
+              </Card>
+            ))}
+          </section>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/renderer/src/features/dashboard/dashboard-model.test.ts
+++ b/apps/renderer/src/features/dashboard/dashboard-model.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import type { DashboardDataset } from "../../reporting";
+import {
+  buildDashboardKpiMetrics,
+  mapDashboardStaleState
+} from "./dashboard-model";
+
+const fixtureDataset: DashboardDataset = {
+  scenarioId: "baseline",
+  staleForecast: false,
+  spendTrend: [
+    { month: "2026-01", forecastMinor: 10000, actualMinor: 11000 },
+    { month: "2026-02", forecastMinor: 15000, actualMinor: 14000 },
+    { month: "2026-03", forecastMinor: 5000, actualMinor: 7000 }
+  ],
+  variance: [
+    {
+      month: "2026-01",
+      forecastMinor: 10000,
+      actualMinor: 11000,
+      varianceMinor: 1000,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    },
+    {
+      month: "2026-02",
+      forecastMinor: 15000,
+      actualMinor: 14000,
+      varianceMinor: -1000,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    },
+    {
+      month: "2026-03",
+      forecastMinor: 5000,
+      actualMinor: 7000,
+      varianceMinor: 2000,
+      unmatchedActualMinor: 500,
+      unmatchedCount: 1
+    }
+  ],
+  renewals: [
+    { month: "2026-04", count: 2 },
+    { month: "2026-05", count: 1 }
+  ],
+  growth: [
+    { month: "2026-01", forecastMinor: 10000, growthPct: null },
+    { month: "2026-02", forecastMinor: 15000, growthPct: 50 },
+    { month: "2026-03", forecastMinor: 5000, growthPct: -66.7 }
+  ],
+  taggingCompleteness: {
+    totalExpenseLines: 10,
+    taggedExpenseLines: 8,
+    completenessRatio: 0.8
+  },
+  replacementStatus: {
+    totalPlans: 5,
+    replacementRequiredOpen: 2,
+    byStatus: [{ status: "draft", count: 5 }]
+  },
+  narrativeBlocks: [{ id: "summary", title: "Summary", body: "..." }]
+};
+
+describe("dashboard model", () => {
+  it("calculates KPI metrics from dataset fixtures", () => {
+    const metrics = buildDashboardKpiMetrics(fixtureDataset);
+    expect(metrics).toEqual({
+      forecastMinor: 30000,
+      actualMinor: 32000,
+      varianceMinor: 2000,
+      renewalCount: 3,
+      taggingCompletenessPct: 80,
+      replacementRequiredOpen: 2
+    });
+  });
+
+  it("maps stale state to a visible warning message", () => {
+    const staleState = mapDashboardStaleState({
+      ...fixtureDataset,
+      staleForecast: true
+    });
+
+    expect(staleState.isStale).toBe(true);
+    expect(staleState.message).toContain("stale");
+  });
+});

--- a/apps/renderer/src/features/dashboard/dashboard-model.ts
+++ b/apps/renderer/src/features/dashboard/dashboard-model.ts
@@ -1,0 +1,45 @@
+import {
+  computeDashboardTotals,
+  getForecastStaleIndicator,
+  type DashboardDataset
+} from "../../reporting";
+
+export type DashboardKpiMetrics = {
+  forecastMinor: number;
+  actualMinor: number;
+  varianceMinor: number;
+  renewalCount: number;
+  taggingCompletenessPct: number;
+  replacementRequiredOpen: number;
+};
+
+export type DashboardStaleState = {
+  isStale: boolean;
+  message: string | null;
+};
+
+export function buildDashboardKpiMetrics(
+  dataset: DashboardDataset
+): DashboardKpiMetrics {
+  const totals = computeDashboardTotals(dataset);
+  const renewalCount = dataset.renewals.reduce((sum, row) => sum + row.count, 0);
+
+  return {
+    forecastMinor: totals.forecastMinor,
+    actualMinor: totals.actualMinor,
+    varianceMinor: totals.varianceMinor,
+    renewalCount,
+    taggingCompletenessPct: dataset.taggingCompleteness.completenessRatio * 100,
+    replacementRequiredOpen: dataset.replacementStatus.replacementRequiredOpen
+  };
+}
+
+export function mapDashboardStaleState(
+  dataset: DashboardDataset
+): DashboardStaleState {
+  const message = getForecastStaleIndicator(dataset);
+  return {
+    isStale: message !== null,
+    message
+  };
+}


### PR DESCRIPTION
## Summary
- replace dashboard placeholder with a data-driven dashboard workspace
- add KPI, stale-state, and chart rendering from eports.query dashboard dataset
- add stale forecast warning banner with Re-materialize action entry point
- add export action menu for HTML/PDF/Excel/CSV/PNG with progress + completion states
- add responsive dashboard layout styles for scaled desktop usage
- add dashboard model, integration, and app-route E2E-style tests

## Test Plan
- npm run lint --workspace @budgetit/renderer
- npm run typecheck --workspace @budgetit/renderer
- npm run test --workspace @budgetit/renderer
- npm run build --workspace @budgetit/renderer

Closes #59