### PR TITLE
[U4] Redesign Alerts page into tabbed triage inbox

### DIFF
--- a/apps/renderer/src/app/app-shell.test.tsx
+++ b/apps/renderer/src/app/app-shell.test.tsx
@@ -44,7 +44,7 @@ describe("AppShell", () => {
 
     expect(screen.getByTestId("page-title")).toHaveTextContent("Alerts");
     expect(
-      screen.getByText("Alerts workspace is being upgraded")
+      screen.getByText("Actionable inbox for due, snoozed, and acknowledged alerts.")
     ).toBeInTheDocument();
   });
 });

--- a/apps/renderer/src/features/alerts/AlertsPage.css
+++ b/apps/renderer/src/features/alerts/AlertsPage.css
@@ -1,0 +1,64 @@
+.alerts-page {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+}
+
+.alerts-layout {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 2fr) minmax(18rem, 1fr);
+}
+
+.alerts-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.alerts-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.alerts-group__items {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.alerts-row {
+  display: grid;
+  gap: 0.5rem;
+  border-left: 3px solid transparent;
+}
+
+.alerts-row--focused {
+  border-left-color: #2563eb;
+}
+
+.alerts-row__meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.alerts-row__actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.alerts-detail ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1rem;
+}
+
+@media (max-width: 1240px) {
+  .alerts-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/apps/renderer/src/features/alerts/AlertsPage.test.tsx
+++ b/apps/renderer/src/features/alerts/AlertsPage.test.tsx
@@ -1,0 +1,162 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor
+} from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  acknowledgeAlert,
+  listAlerts,
+  onAlertNavigate,
+  snoozeAlert,
+  type AlertRecord
+} from "../../lib/ipcClient";
+import { budgetItLightTheme } from "../../ui/theme";
+import { AlertsPage } from "./AlertsPage";
+
+vi.mock("../../lib/ipcClient", () => ({
+  listAlerts: vi.fn(),
+  acknowledgeAlert: vi.fn(),
+  snoozeAlert: vi.fn(),
+  onAlertNavigate: vi.fn(),
+  queryReport: vi.fn(),
+  exportReport: vi.fn()
+}));
+
+const fixtureAlerts: AlertRecord[] = [
+  {
+    id: "alert-1",
+    entityType: "contract",
+    entityId: "contract-1",
+    fireAt: "2026-03-03",
+    status: "pending",
+    snoozedUntil: null,
+    message: "Renewal due in 5 days"
+  },
+  {
+    id: "alert-2",
+    entityType: "contract",
+    entityId: "contract-2",
+    fireAt: "2026-03-18",
+    status: "snoozed",
+    snoozedUntil: "2026-03-10",
+    message: "Notice window opens soon"
+  },
+  {
+    id: "alert-3",
+    entityType: "vendor",
+    entityId: "vendor-3",
+    fireAt: "2026-05-04",
+    status: "acked",
+    snoozedUntil: null,
+    message: "[HIGH] Deadline reached for cancellation"
+  }
+];
+
+const listAlertsMock = vi.mocked(listAlerts);
+const acknowledgeAlertMock = vi.mocked(acknowledgeAlert);
+const snoozeAlertMock = vi.mocked(snoozeAlert);
+const onAlertNavigateMock = vi.mocked(onAlertNavigate);
+
+function renderAlertsPage(initialPath: string = "/alerts") {
+  return render(
+    <FluentProvider theme={budgetItLightTheme}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/alerts" element={<AlertsPage />} />
+        </Routes>
+      </MemoryRouter>
+    </FluentProvider>
+  );
+}
+
+describe("AlertsPage", () => {
+  beforeEach(() => {
+    listAlertsMock.mockReset();
+    acknowledgeAlertMock.mockReset();
+    snoozeAlertMock.mockReset();
+    onAlertNavigateMock.mockReset();
+
+    listAlertsMock.mockResolvedValue(fixtureAlerts);
+    onAlertNavigateMock.mockReturnValue(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("persists tab state from URL and mutates list state after ack", async () => {
+    acknowledgeAlertMock.mockImplementation(async (alertEventId: string) => ({
+      ...fixtureAlerts.find((alert) => alert.id === alertEventId)!,
+      status: "acked",
+      snoozedUntil: null
+    }));
+
+    renderAlertsPage("/alerts?tab=snoozed");
+
+    await screen.findAllByText("Notice window opens soon");
+    expect(screen.getByRole("tab", { name: /Snoozed/ })).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Ack" }));
+
+    await waitFor(() => {
+      expect(acknowledgeAlertMock).toHaveBeenCalledWith("alert-2");
+    });
+    expect(await screen.findByText("No alerts in this tab")).toBeInTheDocument();
+  });
+
+  it("runs snooze quick action and updates alert state", async () => {
+    snoozeAlertMock.mockImplementation(async (alertEventId: string, snoozedUntil: string) => ({
+      ...fixtureAlerts.find((alert) => alert.id === alertEventId)!,
+      status: "snoozed",
+      snoozedUntil
+    }));
+
+    renderAlertsPage("/alerts?tab=dueSoon");
+    await screen.findAllByText("Renewal due in 5 days");
+
+    fireEvent.click(screen.getByRole("button", { name: "Snooze until +7d" }));
+    await waitFor(() => {
+      expect(snoozeAlertMock).toHaveBeenCalledWith(
+        "alert-1",
+        expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/)
+      );
+    });
+    expect(await screen.findByText(/snoozed until/i)).toBeInTheDocument();
+  });
+
+  it("focuses the correct alert after notification deep-link callback", async () => {
+    onAlertNavigateMock.mockImplementation(() => () => {});
+
+    renderAlertsPage("/alerts?tab=all");
+    await screen.findAllByText("Renewal due in 5 days");
+
+    const navigateListener = onAlertNavigateMock.mock.calls[0]?.[0] as
+      | ((payload: { alertEventId: string; entityType: string; entityId: string }) => void)
+      | undefined;
+
+    if (!navigateListener) {
+      throw new Error("Expected alert navigation listener to be registered.");
+    }
+
+    navigateListener({
+      alertEventId: "alert-2",
+      entityType: "contract",
+      entityId: "contract-2"
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Related entity: contract:contract-2")).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("Notice window opens soon").length).toBeGreaterThan(0);
+    expect(screen.getByRole("tab", { name: /All/ })).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/apps/renderer/src/features/alerts/AlertsPage.tsx
+++ b/apps/renderer/src/features/alerts/AlertsPage.tsx
@@ -1,11 +1,348 @@
-import { FeaturePlaceholderPage } from "../common/FeaturePlaceholderPage";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  Card,
+  Tab,
+  TabList,
+  Text,
+  Title3
+} from "@fluentui/react-components";
+import { useSearchParams } from "react-router-dom";
 
-export function AlertsPage() {
-  return (
-    <FeaturePlaceholderPage
-      title="Alerts"
-      description="Alerts inbox workflow with grouping, tabs, and detail drill-in is planned in U4."
-    />
-  );
+import {
+  acknowledgeAlert,
+  listAlerts,
+  onAlertNavigate,
+  snoozeAlert,
+  type AlertRecord
+} from "../../lib/ipcClient";
+import { EmptyState, InlineError, PageHeader, StatusChip } from "../../ui/primitives";
+import {
+  deriveAlertSeverity,
+  extractAlertReason,
+  filterAlertsByTab,
+  groupAlertsByTimeBucket,
+  recommendedNextActions,
+  resolveAlertTab,
+  type AlertTabKey,
+  type AlertSeverity
+} from "./alerts-model";
+import "./AlertsPage.css";
+
+const TAB_LABELS: Record<AlertTabKey, string> = {
+  dueSoon: "Due soon",
+  snoozed: "Snoozed",
+  acked: "Acked",
+  all: "All"
+};
+
+function addDaysToIsoDate(days: number): string {
+  const value = new Date();
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString().slice(0, 10);
 }
 
+function formatDueDate(isoDate: string): string {
+  const date = new Date(`${isoDate}T00:00:00.000Z`);
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC"
+  });
+}
+
+function severityToTone(
+  severity: AlertSeverity
+): "danger" | "warning" | "info" {
+  if (severity === "high") {
+    return "danger";
+  }
+  if (severity === "medium") {
+    return "warning";
+  }
+  return "info";
+}
+
+function statusToTone(status: AlertRecord["status"]): "info" | "warning" | "success" {
+  if (status === "acked") {
+    return "success";
+  }
+  if (status === "snoozed") {
+    return "warning";
+  }
+  return "info";
+}
+
+function buildNextQuery(searchParams: URLSearchParams, updates: Record<string, string | null>): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+  for (const [key, value] of Object.entries(updates)) {
+    if (!value) {
+      next.delete(key);
+    } else {
+      next.set(key, value);
+    }
+  }
+  return next;
+}
+
+export function AlertsPage() {
+  const [alerts, setAlerts] = useState<AlertRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionStatus, setActionStatus] = useState<string | null>(null);
+  const [busyAlertId, setBusyAlertId] = useState<string | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const activeTab = resolveAlertTab(searchParams.get("tab"));
+  const focusedAlertId = searchParams.get("alert");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const nextAlerts = await listAlerts();
+        if (cancelled) {
+          return;
+        }
+        setAlerts(nextAlerts);
+      } catch (loadError) {
+        const detail = loadError instanceof Error ? loadError.message : String(loadError);
+        setError(`Failed to load alerts: ${detail}`);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = onAlertNavigate((payload) => {
+      setActionStatus(`Focused alert ${payload.alertEventId} for ${payload.entityType}:${payload.entityId}.`);
+      setSearchParams(
+        (current) =>
+          buildNextQuery(current, {
+            tab: "all",
+            alert: payload.alertEventId
+          }),
+        { replace: false }
+      );
+    });
+    return () => {
+      if (unsubscribe) {
+        unsubscribe();
+      }
+    };
+  }, [setSearchParams]);
+
+  const tabCounts = useMemo(
+    () => ({
+      dueSoon: filterAlertsByTab(alerts, "dueSoon").length,
+      snoozed: filterAlertsByTab(alerts, "snoozed").length,
+      acked: filterAlertsByTab(alerts, "acked").length,
+      all: alerts.length
+    }),
+    [alerts]
+  );
+
+  const visibleAlerts = useMemo(
+    () => filterAlertsByTab(alerts, activeTab),
+    [alerts, activeTab]
+  );
+  const groupedAlerts = useMemo(
+    () => groupAlertsByTimeBucket(visibleAlerts),
+    [visibleAlerts]
+  );
+
+  const focusedAlert = useMemo(() => {
+    if (focusedAlertId) {
+      return alerts.find((alert) => alert.id === focusedAlertId) ?? null;
+    }
+    return visibleAlerts[0] ?? null;
+  }, [alerts, focusedAlertId, visibleAlerts]);
+
+  function focusAlert(alertId: string): void {
+    setSearchParams(
+      (current) => buildNextQuery(current, { alert: alertId }),
+      { replace: false }
+    );
+  }
+
+  async function handleAck(alertId: string): Promise<void> {
+    setBusyAlertId(alertId);
+    try {
+      const updated = await acknowledgeAlert(alertId);
+      setAlerts((current) =>
+        current.map((alert) => (alert.id === alertId ? updated : alert))
+      );
+      setActionStatus(`Alert ${alertId} acknowledged.`);
+    } catch (actionError) {
+      const detail = actionError instanceof Error ? actionError.message : String(actionError);
+      setError(`Failed to acknowledge alert: ${detail}`);
+    } finally {
+      setBusyAlertId(null);
+    }
+  }
+
+  async function handleSnooze(alertId: string, days: number): Promise<void> {
+    const snoozedUntil = addDaysToIsoDate(days);
+    setBusyAlertId(alertId);
+    try {
+      const updated = await snoozeAlert(alertId, snoozedUntil);
+      setAlerts((current) =>
+        current.map((alert) => (alert.id === alertId ? updated : alert))
+      );
+      setActionStatus(`Alert ${alertId} snoozed until ${snoozedUntil}.`);
+    } catch (actionError) {
+      const detail = actionError instanceof Error ? actionError.message : String(actionError);
+      setError(`Failed to snooze alert: ${detail}`);
+    } finally {
+      setBusyAlertId(null);
+    }
+  }
+
+  function handleOpenEntity(alert: AlertRecord): void {
+    focusAlert(alert.id);
+    setActionStatus(`Open entity ${alert.entityType}:${alert.entityId}.`);
+  }
+
+  return (
+    <section className="alerts-page">
+      <PageHeader
+        title="Alerts Inbox"
+        subtitle="Actionable inbox for due, snoozed, and acknowledged alerts."
+      />
+
+      <TabList
+        selectedValue={activeTab}
+        onTabSelect={(_event, data) => {
+          setSearchParams(
+            (current) =>
+              buildNextQuery(current, { tab: String(data.value), alert: focusedAlertId }),
+            { replace: false }
+          );
+        }}
+      >
+        <Tab value="dueSoon">{`${TAB_LABELS.dueSoon} (${tabCounts.dueSoon})`}</Tab>
+        <Tab value="snoozed">{`${TAB_LABELS.snoozed} (${tabCounts.snoozed})`}</Tab>
+        <Tab value="acked">{`${TAB_LABELS.acked} (${tabCounts.acked})`}</Tab>
+        <Tab value="all">{`${TAB_LABELS.all} (${tabCounts.all})`}</Tab>
+      </TabList>
+
+      {error ? <InlineError message={error} /> : null}
+      {actionStatus ? <Text>{actionStatus}</Text> : null}
+
+      <div className="alerts-layout">
+        <section className="alerts-list">
+          {loading ? (
+            <Card>
+              <Text>Loading alerts...</Text>
+            </Card>
+          ) : groupedAlerts.length === 0 ? (
+            <EmptyState
+              title="No alerts in this tab"
+              description="You're clear for the selected triage view."
+            />
+          ) : (
+            groupedAlerts.map((group) => (
+              <section className="alerts-group" key={group.bucket}>
+                <Title3>{group.label}</Title3>
+                <ul className="alerts-group__items">
+                  {group.alerts.map((alert) => {
+                    const severity = deriveAlertSeverity(alert);
+                    const isFocused = focusedAlert?.id === alert.id;
+                    return (
+                      <li key={alert.id}>
+                        <Card
+                          className={isFocused ? "alerts-row alerts-row--focused" : "alerts-row"}
+                        >
+                          <div className="alerts-row__meta">
+                            <StatusChip
+                              label={severity.toUpperCase()}
+                              tone={severityToTone(severity)}
+                            />
+                            <StatusChip
+                              label={alert.status.toUpperCase()}
+                              tone={statusToTone(alert.status)}
+                            />
+                            <Text>{formatDueDate(alert.fireAt)}</Text>
+                          </div>
+                          <Text>{alert.message}</Text>
+                          <div className="alerts-row__actions">
+                            <Button
+                              size="small"
+                              appearance="secondary"
+                              onClick={() => focusAlert(alert.id)}
+                            >
+                              Review
+                            </Button>
+                            <Button
+                              size="small"
+                              appearance="secondary"
+                              disabled={alert.status === "acked" || busyAlertId === alert.id}
+                              onClick={() => void handleAck(alert.id)}
+                            >
+                              Ack
+                            </Button>
+                            <Button
+                              size="small"
+                              appearance="secondary"
+                              disabled={alert.status === "acked" || busyAlertId === alert.id}
+                              onClick={() => void handleSnooze(alert.id, 7)}
+                            >
+                              Snooze until +7d
+                            </Button>
+                            <Button
+                              size="small"
+                              appearance="secondary"
+                              onClick={() => handleOpenEntity(alert)}
+                            >
+                              Open entity
+                            </Button>
+                          </div>
+                        </Card>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </section>
+            ))
+          )}
+        </section>
+
+        <aside className="alerts-detail">
+          {focusedAlert ? (
+            <Card>
+              <Title3>Alert Detail</Title3>
+              <Text>{focusedAlert.message}</Text>
+              <Text>{`Due: ${formatDueDate(focusedAlert.fireAt)}`}</Text>
+              <Text>{`Related entity: ${focusedAlert.entityType}:${focusedAlert.entityId}`}</Text>
+              <Text>{`Trigger reason: ${extractAlertReason(focusedAlert)}`}</Text>
+              <Text weight="semibold">Recommended next actions</Text>
+              <ul>
+                {recommendedNextActions(focusedAlert).map((item) => (
+                  <li key={item}>
+                    <Text>{item}</Text>
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          ) : (
+            <EmptyState
+              title="No alert selected"
+              description="Select an alert from the inbox to inspect details."
+            />
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/apps/renderer/src/features/alerts/alerts-model.test.ts
+++ b/apps/renderer/src/features/alerts/alerts-model.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import type { AlertRecord } from "../../lib/ipcClient";
+import {
+  deriveAlertSeverity,
+  filterAlertsByTab,
+  groupAlertsByTimeBucket
+} from "./alerts-model";
+
+const fixtureAlerts: AlertRecord[] = [
+  {
+    id: "alert-1",
+    entityType: "contract",
+    entityId: "contract-1",
+    fireAt: "2026-03-02",
+    status: "pending",
+    snoozedUntil: null,
+    message: "Renewal due in 5 days"
+  },
+  {
+    id: "alert-2",
+    entityType: "contract",
+    entityId: "contract-2",
+    fireAt: "2026-03-20",
+    status: "snoozed",
+    snoozedUntil: "2026-03-10",
+    message: "Notice window opens soon"
+  },
+  {
+    id: "alert-3",
+    entityType: "service",
+    entityId: "service-3",
+    fireAt: "2026-05-10",
+    status: "acked",
+    snoozedUntil: null,
+    message: "[HIGH] Deadline reached for cancellation"
+  }
+];
+
+describe("alerts model", () => {
+  it("groups alerts into expected date buckets for triage", () => {
+    const groups = groupAlertsByTimeBucket(
+      fixtureAlerts,
+      new Date("2026-03-01T00:00:00.000Z")
+    );
+
+    expect(groups.map((group) => group.bucket)).toEqual([
+      "thisWeek",
+      "next30Days",
+      "later"
+    ]);
+    expect(groups[0].alerts.map((alert) => alert.id)).toEqual(["alert-1"]);
+    expect(groups[1].alerts.map((alert) => alert.id)).toEqual(["alert-2"]);
+    expect(groups[2].alerts.map((alert) => alert.id)).toEqual(["alert-3"]);
+  });
+
+  it("filters by tab status and maps severity consistently", () => {
+    expect(filterAlertsByTab(fixtureAlerts, "dueSoon").map((alert) => alert.id)).toEqual([
+      "alert-1"
+    ]);
+    expect(filterAlertsByTab(fixtureAlerts, "snoozed").map((alert) => alert.id)).toEqual([
+      "alert-2"
+    ]);
+    expect(filterAlertsByTab(fixtureAlerts, "acked").map((alert) => alert.id)).toEqual([
+      "alert-3"
+    ]);
+    expect(deriveAlertSeverity(fixtureAlerts[0])).toBe("medium");
+    expect(deriveAlertSeverity(fixtureAlerts[2])).toBe("high");
+  });
+});

--- a/apps/renderer/src/features/alerts/alerts-model.ts
+++ b/apps/renderer/src/features/alerts/alerts-model.ts
@@ -1,0 +1,124 @@
+import type { AlertRecord } from "../../lib/ipcClient";
+
+export type AlertTabKey = "dueSoon" | "snoozed" | "acked" | "all";
+export type AlertTimeBucket = "thisWeek" | "next30Days" | "later";
+export type AlertSeverity = "high" | "medium" | "info";
+
+export const ALERT_BUCKET_LABELS: Record<AlertTimeBucket, string> = {
+  thisWeek: "This week",
+  next30Days: "Next 30 days",
+  later: "Later"
+};
+
+const ALERT_BUCKET_ORDER: AlertTimeBucket[] = ["thisWeek", "next30Days", "later"];
+
+function toUtcDateOnly(value: Date): Date {
+  return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()));
+}
+
+function parseIsoDate(value: string): Date {
+  const [year, month, day] = value.split("-").map((part) => Number.parseInt(part, 10));
+  return new Date(Date.UTC(year, (month || 1) - 1, day || 1));
+}
+
+function daysUntil(baseDate: Date, targetIsoDate: string): number {
+  const base = toUtcDateOnly(baseDate);
+  const target = parseIsoDate(targetIsoDate);
+  const differenceMs = target.getTime() - base.getTime();
+  return Math.floor(differenceMs / (24 * 60 * 60 * 1000));
+}
+
+export function resolveAlertTab(candidate: string | null): AlertTabKey {
+  if (candidate === "snoozed" || candidate === "acked" || candidate === "all" || candidate === "dueSoon") {
+    return candidate;
+  }
+  return "dueSoon";
+}
+
+export function filterAlertsByTab(alerts: AlertRecord[], tab: AlertTabKey): AlertRecord[] {
+  if (tab === "all") {
+    return [...alerts];
+  }
+  if (tab === "snoozed") {
+    return alerts.filter((alert) => alert.status === "snoozed");
+  }
+  if (tab === "acked") {
+    return alerts.filter((alert) => alert.status === "acked");
+  }
+  return alerts.filter((alert) => alert.status === "pending");
+}
+
+function getAlertTimeBucket(alert: AlertRecord, now: Date): AlertTimeBucket {
+  const dayDelta = daysUntil(now, alert.fireAt);
+  if (dayDelta <= 7) {
+    return "thisWeek";
+  }
+  if (dayDelta <= 30) {
+    return "next30Days";
+  }
+  return "later";
+}
+
+export type AlertBucketGroup = {
+  bucket: AlertTimeBucket;
+  label: string;
+  alerts: AlertRecord[];
+};
+
+export function groupAlertsByTimeBucket(
+  alerts: AlertRecord[],
+  now: Date = new Date()
+): AlertBucketGroup[] {
+  const grouped: Record<AlertTimeBucket, AlertRecord[]> = {
+    thisWeek: [],
+    next30Days: [],
+    later: []
+  };
+
+  const sortedAlerts = [...alerts].sort((left, right) => left.fireAt.localeCompare(right.fireAt));
+  for (const alert of sortedAlerts) {
+    grouped[getAlertTimeBucket(alert, now)].push(alert);
+  }
+
+  return ALERT_BUCKET_ORDER.map((bucket) => ({
+    bucket,
+    label: ALERT_BUCKET_LABELS[bucket],
+    alerts: grouped[bucket]
+  })).filter((group) => group.alerts.length > 0);
+}
+
+export function deriveAlertSeverity(alert: AlertRecord): AlertSeverity {
+  const message = alert.message.toLowerCase();
+  if (message.includes("[high]") || message.includes("deadline") || message.includes("expired")) {
+    return "high";
+  }
+  if (message.includes("renewal") || message.includes("notice") || message.includes("due")) {
+    return "medium";
+  }
+  return "info";
+}
+
+export function extractAlertReason(alert: AlertRecord): string {
+  return alert.message.replace(/\[HIGH\]\s*/gi, "").trim();
+}
+
+export function recommendedNextActions(alert: AlertRecord): string[] {
+  if (alert.status === "acked") {
+    return [
+      "No immediate triage required.",
+      "Re-open related entity only if the situation changes."
+    ];
+  }
+
+  if (alert.status === "snoozed") {
+    return [
+      "Track the snoozed-until date and re-evaluate before the due date.",
+      "Unsnooze early if contract/vendor context has changed."
+    ];
+  }
+
+  return [
+    "Review the linked entity details and confirm upcoming deadlines.",
+    "Acknowledge or snooze after triage to keep inbox focused."
+  ];
+}


### PR DESCRIPTION
## Summary
- replace alerts placeholder with a triage inbox workflow
- add tabbed views: Due soon, Snoozed, Acked, and All
- add time-bucket grouping: This week, Next 30 days, Later
- add row quick actions: Review, Ack, Snooze until +7d, Open entity
- add detail pane with trigger reason, related entity, and recommended next actions
- wire deep-link notification payloads via onAlertNavigate to focus the correct alert and entity context
- persist tab/focus state via URL search params for route-refresh continuity

## Test Plan
- npm run lint --workspace @budgetit/renderer
- npm run typecheck --workspace @budgetit/renderer
- npm run test --workspace @budgetit/renderer
- npm run build --workspace @budgetit/renderer

Closes #60