### PR TITLE
feat(ui): implement U6 services and contracts lifecycle workspaces

### DIFF
--- a/apps/renderer/src/features/contracts/ContractsPage.css
+++ b/apps/renderer/src/features/contracts/ContractsPage.css
@@ -1,0 +1,63 @@
+.contracts-page {
+  display: grid;
+  gap: 1rem;
+}
+
+.contracts-toolbar {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 1fr minmax(180px, 260px);
+}
+
+.contracts-layout {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.75fr) minmax(280px, 1fr);
+}
+
+.contracts-row--selected {
+  background: color-mix(in srgb, var(--colorNeutralBackground1) 70%, var(--colorBrandBackground) 30%);
+}
+
+.contracts-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.contracts-detail {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.contracts-detail__list {
+  display: grid;
+  gap: 0.5rem;
+  list-style: disc;
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.contracts-linked-service {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+.contracts-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+@media (max-width: 980px) {
+  .contracts-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .contracts-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/renderer/src/features/contracts/ContractsPage.tsx
+++ b/apps/renderer/src/features/contracts/ContractsPage.tsx
@@ -1,11 +1,340 @@
-import { FeaturePlaceholderPage } from "../common/FeaturePlaceholderPage";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  Card,
+  Input,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Text,
+  Title3
+} from "@fluentui/react-components";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
-export function ContractsPage() {
-  return (
-    <FeaturePlaceholderPage
-      title="Contracts"
-      description="Contract lifecycle workspace with renewal actions and linked service context is planned in U6."
-    />
-  );
+import { EmptyState, PageHeader, StatusChip } from "../../ui/primitives";
+import {
+  CONTRACT_RECORDS,
+  SERVICE_BY_ID,
+  type ContractLifecycleStatus
+} from "../services/service-contract-data";
+import {
+  contractLifecycleTone,
+  renewalWindowLabel
+} from "../services/service-lifecycle-model";
+import "./ContractsPage.css";
+
+const REFERENCE_DATE = "2026-03-01";
+
+function formatDate(isoDate: string): string {
+  return new Date(`${isoDate}T00:00:00.000Z`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC"
+  });
 }
 
+function formatUsd(amountMinor: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD"
+  }).format(amountMinor / 100);
+}
+
+function mergeQuery(
+  params: URLSearchParams,
+  updates: Record<string, string | null>
+): URLSearchParams {
+  const next = new URLSearchParams(params);
+  for (const [key, value] of Object.entries(updates)) {
+    if (!value) {
+      next.delete(key);
+    } else {
+      next.set(key, value);
+    }
+  }
+  return next;
+}
+
+export function ContractsPage() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [query, setQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState<ContractLifecycleStatus | "all">(
+    "all"
+  );
+  const [selectedContractId, setSelectedContractId] = useState<string>(() => {
+    return searchParams.get("contract") ?? CONTRACT_RECORDS[0]?.id ?? "";
+  });
+  const [message, setMessage] = useState<string | null>(null);
+
+  const visibleContracts = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    return CONTRACT_RECORDS.filter((contract) => {
+      if (statusFilter !== "all" && contract.lifecycleStatus !== statusFilter) {
+        return false;
+      }
+      if (!normalized) {
+        return true;
+      }
+      return (
+        contract.contractNumber.toLowerCase().includes(normalized) ||
+        contract.providerName.toLowerCase().includes(normalized) ||
+        contract.owner.toLowerCase().includes(normalized)
+      );
+    });
+  }, [query, statusFilter]);
+
+  useEffect(() => {
+    if (visibleContracts.length === 0) {
+      return;
+    }
+    if (!visibleContracts.some((contract) => contract.id === selectedContractId)) {
+      setSelectedContractId(visibleContracts[0].id);
+    }
+  }, [selectedContractId, visibleContracts]);
+
+  useEffect(() => {
+    if (!selectedContractId) {
+      return;
+    }
+    setSearchParams(
+      (current) =>
+        mergeQuery(current, {
+          contract: selectedContractId
+        }),
+      { replace: true }
+    );
+  }, [selectedContractId, setSearchParams]);
+
+  const selectedContract =
+    CONTRACT_RECORDS.find((contract) => contract.id === selectedContractId) ??
+    visibleContracts[0] ??
+    null;
+
+  function openService(serviceId: string): void {
+    navigate(`/services?service=${serviceId}&tab=contracts`);
+  }
+
+  function openAlert(contractId: string): void {
+    navigate(`/alerts?tab=all&entityType=contract&entityId=${contractId}`);
+  }
+
+  function openReplacement(contractId: string): void {
+    navigate(`/reports?replacementContractId=${contractId}`);
+  }
+
+  return (
+    <section className="contracts-page">
+      <PageHeader
+        title="Contracts Workspace"
+        subtitle="Contract lifecycle management with linked services, renewal actions, and replacement pathways."
+      />
+
+      <div className="contracts-toolbar">
+        <Input
+          aria-label="Search contracts"
+          placeholder="Search contract number, provider, or owner"
+          value={query}
+          onChange={(_event, data) => setQuery(data.value)}
+        />
+        <Select
+          aria-label="Filter by contract status"
+          value={statusFilter}
+          onChange={(event) =>
+            setStatusFilter(event.target.value as ContractLifecycleStatus | "all")
+          }
+        >
+          <option value="all">All statuses</option>
+          <option value="active">Active</option>
+          <option value="renewal-window">Renewal window</option>
+          <option value="notice-window">Notice window</option>
+          <option value="expired">Expired</option>
+        </Select>
+      </div>
+
+      {message ? <Text>{message}</Text> : null}
+
+      <div className="contracts-layout">
+        <section>
+          {visibleContracts.length === 0 ? (
+            <EmptyState
+              title="No contracts match filters"
+              description="Adjust search text or status filters to inspect contract records."
+            />
+          ) : (
+            <Table aria-label="Contracts table">
+              <TableHeader>
+                <TableRow>
+                  <TableHeaderCell>Contract</TableHeaderCell>
+                  <TableHeaderCell>Provider</TableHeaderCell>
+                  <TableHeaderCell>Renewal</TableHeaderCell>
+                  <TableHeaderCell>Notice deadline</TableHeaderCell>
+                  <TableHeaderCell>Commitment</TableHeaderCell>
+                  <TableHeaderCell>Linked services</TableHeaderCell>
+                  <TableHeaderCell>Status</TableHeaderCell>
+                  <TableHeaderCell>Actions</TableHeaderCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {visibleContracts.map((contract) => {
+                  const firstServiceId = contract.linkedServiceIds[0] ?? null;
+                  const selected = selectedContract?.id === contract.id;
+                  return (
+                    <TableRow
+                      key={contract.id}
+                      className={
+                        selected ? "contracts-row contracts-row--selected" : "contracts-row"
+                      }
+                      onClick={() => setSelectedContractId(contract.id)}
+                    >
+                      <TableCell>{contract.contractNumber}</TableCell>
+                      <TableCell>{contract.providerName}</TableCell>
+                      <TableCell>
+                        <Text>{formatDate(contract.renewalDate)}</Text>
+                        <Text size={200}>
+                          {renewalWindowLabel(contract.renewalDate, REFERENCE_DATE)}
+                        </Text>
+                      </TableCell>
+                      <TableCell>{formatDate(contract.noticeDeadline)}</TableCell>
+                      <TableCell>{formatUsd(contract.totalCommitmentMinor)}</TableCell>
+                      <TableCell data-testid={`contract-linked-count-${contract.id}`}>
+                        {contract.linkedServiceIds.length}
+                      </TableCell>
+                      <TableCell>
+                        <StatusChip
+                          label={contract.lifecycleStatus.toUpperCase()}
+                          tone={contractLifecycleTone(contract.lifecycleStatus)}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <div className="contracts-row__actions">
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setSelectedContractId(contract.id);
+                            }}
+                          >
+                            Review
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            disabled={!firstServiceId}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              if (!firstServiceId) {
+                                return;
+                              }
+                              openService(firstServiceId);
+                            }}
+                          >
+                            Open service
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openAlert(contract.id);
+                            }}
+                          >
+                            Open alert
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openReplacement(contract.id);
+                            }}
+                          >
+                            Open replacement
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </section>
+
+        <aside>
+          {selectedContract ? (
+            <Card className="contracts-detail">
+              <Title3>Contract Detail</Title3>
+              <Text>{selectedContract.contractNumber}</Text>
+              <Text>{`Provider: ${selectedContract.providerName}`}</Text>
+              <Text>{`Owner: ${selectedContract.owner}`}</Text>
+              <Text>{`Term: ${formatDate(selectedContract.startDate)} to ${formatDate(
+                selectedContract.endDate
+              )}`}</Text>
+              <Text>{`Renewal action: ${selectedContract.renewalAction}`}</Text>
+              <Text weight="semibold">Linked services</Text>
+              <ul className="contracts-detail__list">
+                {selectedContract.linkedServiceIds.map((serviceId) => {
+                  const service = SERVICE_BY_ID[serviceId];
+                  if (!service) {
+                    return null;
+                  }
+                  return (
+                    <li key={service.id} className="contracts-linked-service">
+                      <Text>{service.name}</Text>
+                      <Button
+                        size="small"
+                        appearance="secondary"
+                        onClick={() => openService(service.id)}
+                      >
+                        {`Open service ${service.name}`}
+                      </Button>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div className="contracts-detail__actions">
+                <Button
+                  size="small"
+                  appearance="secondary"
+                  onClick={() => openAlert(selectedContract.id)}
+                >
+                  Open related alert
+                </Button>
+                <Button
+                  size="small"
+                  appearance="secondary"
+                  onClick={() => openReplacement(selectedContract.id)}
+                >
+                  Open replacement workspace
+                </Button>
+                <Button
+                  size="small"
+                  appearance="primary"
+                  onClick={() =>
+                    setMessage(
+                      `Renewal review started for ${selectedContract.contractNumber}.`
+                    )
+                  }
+                >
+                  Start renewal review
+                </Button>
+              </div>
+            </Card>
+          ) : (
+            <EmptyState
+              title="No contract selected"
+              description="Select a contract row to inspect metadata and linked services."
+            />
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/apps/renderer/src/features/services/ServiceContractWorkspaces.test.tsx
+++ b/apps/renderer/src/features/services/ServiceContractWorkspaces.test.tsx
@@ -1,0 +1,101 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AppShell } from "../../app/AppShell";
+import { AppRoutes } from "../../app/routes";
+import { budgetItLightTheme } from "../../ui/theme";
+
+function renderWorkspace(initialPath: string) {
+  return render(
+    <FluentProvider theme={budgetItLightTheme}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <AppShell>
+          <AppRoutes />
+        </AppShell>
+      </MemoryRouter>
+    </FluentProvider>
+  );
+}
+
+describe("service and contract workspaces", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps service-contract linkage counts consistent and opens linked contract", async () => {
+    renderWorkspace("/services");
+
+    await screen.findByText("Services Workspace");
+    expect(
+      screen.getByTestId("service-linked-count-svc-identity-sso")
+    ).toHaveTextContent("2");
+
+    const serviceRow = screen
+      .getByTestId("service-linked-count-svc-identity-sso")
+      .closest("tr");
+    if (!serviceRow) {
+      throw new Error("Expected Identity SSO table row.");
+    }
+
+    fireEvent.click(
+      within(serviceRow).getByRole("button", { name: "Open contract" })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Contracts");
+    });
+    expect(screen.getByText("Contract Detail")).toBeInTheDocument();
+    expect(screen.getAllByText("CTR-SSO-001").length).toBeGreaterThan(0);
+    expect(
+      screen.getByTestId("contract-linked-count-ctr-sso-main")
+    ).toHaveTextContent("1");
+  });
+
+  it("supports service to contract to related alert navigation path", async () => {
+    renderWorkspace("/services?service=svc-cloud-platform&tab=contracts");
+
+    await screen.findByRole("button", { name: "Open contract CTR-CLOUD-OPS-07" });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open contract CTR-CLOUD-OPS-07" })
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Contracts");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open related alert" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Alerts");
+    });
+    expect(screen.getByText("Alerts Inbox")).toBeInTheDocument();
+  });
+
+  it("opens replacement path from contracts workspace", async () => {
+    renderWorkspace("/contracts?contract=ctr-cloud-ops");
+
+    await screen.findByText("Contract Detail");
+    fireEvent.click(screen.getByRole("button", { name: "Open replacement workspace" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Reports");
+    });
+    expect(
+      screen.getByText(
+        "Report gallery and configurable reporting workspace with export orchestration are planned in U11."
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/renderer/src/features/services/ServicesPage.css
+++ b/apps/renderer/src/features/services/ServicesPage.css
@@ -1,0 +1,72 @@
+.services-page {
+  display: grid;
+  gap: 1rem;
+}
+
+.services-toolbar {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: 1fr minmax(160px, 220px);
+}
+
+.services-layout {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.75fr) minmax(260px, 1fr);
+}
+
+.services-row--selected {
+  background: color-mix(in srgb, var(--colorNeutralBackground1) 70%, var(--colorBrandBackground) 30%);
+}
+
+.services-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.services-renewal {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.services-renewal--highlight {
+  color: var(--colorPaletteRedForeground1);
+  font-weight: 700;
+}
+
+.services-detail {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.services-detail__section {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.services-detail__list {
+  display: grid;
+  gap: 0.5rem;
+  list-style: disc;
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.services-linked-contract {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+@media (max-width: 980px) {
+  .services-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .services-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/renderer/src/features/services/ServicesPage.tsx
+++ b/apps/renderer/src/features/services/ServicesPage.tsx
@@ -1,11 +1,425 @@
-import { FeaturePlaceholderPage } from "../common/FeaturePlaceholderPage";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  Card,
+  Input,
+  Select,
+  Tab,
+  TabList,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Text,
+  Title3
+} from "@fluentui/react-components";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
-export function ServicesPage() {
-  return (
-    <FeaturePlaceholderPage
-      title="Services"
-      description="Lifecycle-centric services workspace with linked contracts, renewals, and replacement status is planned in U6."
-    />
-  );
+import { EmptyState, PageHeader, StatusChip } from "../../ui/primitives";
+import {
+  CONTRACT_BY_ID,
+  SERVICE_RECORDS,
+  type ServiceRecord,
+  type ServiceRisk
+} from "./service-contract-data";
+import {
+  deriveServiceLifecycleState,
+  isInRenewalWindow,
+  renewalWindowLabel,
+  serviceLifecycleTone,
+  serviceRiskTone
+} from "./service-lifecycle-model";
+import "./ServicesPage.css";
+
+type ServiceDetailTab =
+  | "overview"
+  | "expenses"
+  | "contracts"
+  | "renewals"
+  | "replacement";
+
+const REFERENCE_DATE = "2026-03-01";
+
+function resolveDetailTab(value: string | null): ServiceDetailTab {
+  if (
+    value === "overview" ||
+    value === "expenses" ||
+    value === "contracts" ||
+    value === "renewals" ||
+    value === "replacement"
+  ) {
+    return value;
+  }
+  return "overview";
 }
 
+function mergeQuery(
+  params: URLSearchParams,
+  updates: Record<string, string | null>
+): URLSearchParams {
+  const next = new URLSearchParams(params);
+  for (const [key, value] of Object.entries(updates)) {
+    if (!value) {
+      next.delete(key);
+    } else {
+      next.set(key, value);
+    }
+  }
+  return next;
+}
+
+function formatUsd(amountMinor: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD"
+  }).format(amountMinor / 100);
+}
+
+function formatDate(isoDate: string): string {
+  return new Date(`${isoDate}T00:00:00.000Z`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC"
+  });
+}
+
+function primaryContractId(service: ServiceRecord): string | null {
+  return service.linkedContractIds[0] ?? null;
+}
+
+export function ServicesPage() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [query, setQuery] = useState("");
+  const [riskFilter, setRiskFilter] = useState<ServiceRisk | "all">("all");
+  const [detailTab, setDetailTab] = useState<ServiceDetailTab>(() =>
+    resolveDetailTab(searchParams.get("tab"))
+  );
+  const [selectedServiceId, setSelectedServiceId] = useState<string>(() => {
+    return searchParams.get("service") ?? SERVICE_RECORDS[0]?.id ?? "";
+  });
+
+  const visibleServices = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    return SERVICE_RECORDS.filter((service) => {
+      if (riskFilter !== "all" && service.risk !== riskFilter) {
+        return false;
+      }
+      if (!normalized) {
+        return true;
+      }
+      return (
+        service.name.toLowerCase().includes(normalized) ||
+        service.vendorName.toLowerCase().includes(normalized) ||
+        service.owner.toLowerCase().includes(normalized)
+      );
+    });
+  }, [query, riskFilter]);
+
+  useEffect(() => {
+    if (visibleServices.length === 0) {
+      return;
+    }
+    if (!visibleServices.some((service) => service.id === selectedServiceId)) {
+      setSelectedServiceId(visibleServices[0].id);
+    }
+  }, [selectedServiceId, visibleServices]);
+
+  useEffect(() => {
+    if (!selectedServiceId) {
+      return;
+    }
+    setSearchParams(
+      (current) =>
+        mergeQuery(current, {
+          service: selectedServiceId,
+          tab: detailTab
+        }),
+      { replace: true }
+    );
+  }, [detailTab, selectedServiceId, setSearchParams]);
+
+  const selectedService =
+    SERVICE_RECORDS.find((service) => service.id === selectedServiceId) ??
+    visibleServices[0] ??
+    null;
+
+  function openContract(contractId: string, serviceId: string): void {
+    navigate(`/contracts?contract=${contractId}&service=${serviceId}`);
+  }
+
+  function openAlert(serviceId: string): void {
+    navigate(`/alerts?tab=all&entityType=service&entityId=${serviceId}`);
+  }
+
+  function openReplacement(serviceId: string): void {
+    navigate(`/reports?replacementServiceId=${serviceId}`);
+  }
+
+  return (
+    <section className="services-page">
+      <PageHeader
+        title="Services Workspace"
+        subtitle="Lifecycle-focused service management with renewal context and replacement pathways."
+      />
+
+      <div className="services-toolbar">
+        <Input
+          aria-label="Search services"
+          placeholder="Search service, vendor, or owner"
+          value={query}
+          onChange={(_event, data) => setQuery(data.value)}
+        />
+        <Select
+          aria-label="Filter by risk"
+          value={riskFilter}
+          onChange={(event) =>
+            setRiskFilter(event.target.value as ServiceRisk | "all")
+          }
+        >
+          <option value="all">All risks</option>
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+        </Select>
+      </div>
+
+      <div className="services-layout">
+        <section>
+          {visibleServices.length === 0 ? (
+            <EmptyState
+              title="No services match filters"
+              description="Adjust search text or risk filter to see lifecycle records."
+            />
+          ) : (
+            <Table aria-label="Services table">
+              <TableHeader>
+                <TableRow>
+                  <TableHeaderCell>Service</TableHeaderCell>
+                  <TableHeaderCell>Vendor</TableHeaderCell>
+                  <TableHeaderCell>Renewal</TableHeaderCell>
+                  <TableHeaderCell>Annual spend</TableHeaderCell>
+                  <TableHeaderCell>Risk</TableHeaderCell>
+                  <TableHeaderCell>Replacement</TableHeaderCell>
+                  <TableHeaderCell>Linked contracts</TableHeaderCell>
+                  <TableHeaderCell>Actions</TableHeaderCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {visibleServices.map((service) => {
+                  const lifecycleState = deriveServiceLifecycleState(
+                    service.renewalDate,
+                    service.risk,
+                    REFERENCE_DATE
+                  );
+                  const highlightRenewal = isInRenewalWindow(
+                    service.renewalDate,
+                    REFERENCE_DATE,
+                    60
+                  );
+                  const firstContractId = primaryContractId(service);
+                  const selected = selectedService?.id === service.id;
+
+                  return (
+                    <TableRow
+                      key={service.id}
+                      className={selected ? "services-row services-row--selected" : "services-row"}
+                      onClick={() => setSelectedServiceId(service.id)}
+                    >
+                      <TableCell>{service.name}</TableCell>
+                      <TableCell>{service.vendorName}</TableCell>
+                      <TableCell>
+                        <Text
+                          className={
+                            highlightRenewal
+                              ? "services-renewal services-renewal--highlight"
+                              : "services-renewal"
+                          }
+                        >
+                          {formatDate(service.renewalDate)}
+                        </Text>
+                        <StatusChip
+                          label={lifecycleState.toUpperCase()}
+                          tone={serviceLifecycleTone(lifecycleState)}
+                        />
+                      </TableCell>
+                      <TableCell>{formatUsd(service.annualSpendMinor)}</TableCell>
+                      <TableCell>
+                        <StatusChip
+                          label={service.risk.toUpperCase()}
+                          tone={serviceRiskTone(service.risk)}
+                        />
+                      </TableCell>
+                      <TableCell>{service.replacementStatus}</TableCell>
+                      <TableCell data-testid={`service-linked-count-${service.id}`}>
+                        {service.linkedContractIds.length}
+                      </TableCell>
+                      <TableCell>
+                        <div className="services-row__actions">
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setSelectedServiceId(service.id);
+                            }}
+                          >
+                            Review
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            disabled={!firstContractId}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              if (!firstContractId) {
+                                return;
+                              }
+                              openContract(firstContractId, service.id);
+                            }}
+                          >
+                            Open contract
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openAlert(service.id);
+                            }}
+                          >
+                            Open alert
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openReplacement(service.id);
+                            }}
+                          >
+                            Open replacement
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </section>
+
+        <aside>
+          {selectedService ? (
+            <Card className="services-detail">
+              <Title3>{selectedService.name}</Title3>
+              <Text>{`Owner: ${selectedService.owner}`}</Text>
+              <Text>{`Vendor: ${selectedService.vendorName}`}</Text>
+              <Text>{`Renewal: ${formatDate(selectedService.renewalDate)} (${renewalWindowLabel(
+                selectedService.renewalDate,
+                REFERENCE_DATE
+              )})`}</Text>
+
+              <TabList
+                selectedValue={detailTab}
+                onTabSelect={(_event, data) =>
+                  setDetailTab(resolveDetailTab(String(data.value)))
+                }
+              >
+                <Tab value="overview">Overview</Tab>
+                <Tab value="expenses">Expenses</Tab>
+                <Tab value="contracts">Contracts</Tab>
+                <Tab value="renewals">Renewals</Tab>
+                <Tab value="replacement">Replacement Plan</Tab>
+              </TabList>
+
+              {detailTab === "overview" ? (
+                <div className="services-detail__section">
+                  <Text>{`Annual spend: ${formatUsd(selectedService.annualSpendMinor)}`}</Text>
+                  <Text>{`Risk level: ${selectedService.risk}`}</Text>
+                  <Text>{`Replacement status: ${selectedService.replacementStatus}`}</Text>
+                </div>
+              ) : null}
+
+              {detailTab === "expenses" ? (
+                <div className="services-detail__section">
+                  <Text weight="semibold">Linked expense lines</Text>
+                  <ul className="services-detail__list">
+                    {selectedService.expenseLines.map((line) => (
+                      <li key={line.id}>
+                        <Text>{`${line.name} - ${formatUsd(line.amountMinor)} (${line.status})`}</Text>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              {detailTab === "contracts" ? (
+                <div className="services-detail__section">
+                  <Text weight="semibold">Linked contracts</Text>
+                  <ul className="services-detail__list">
+                    {selectedService.linkedContractIds.map((contractId) => {
+                      const contract = CONTRACT_BY_ID[contractId];
+                      if (!contract) {
+                        return null;
+                      }
+                      return (
+                        <li key={contract.id} className="services-linked-contract">
+                          <Text>{`${contract.contractNumber} - ${contract.providerName}`}</Text>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={() => openContract(contract.id, selectedService.id)}
+                          >
+                            {`Open contract ${contract.contractNumber}`}
+                          </Button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              ) : null}
+
+              {detailTab === "renewals" ? (
+                <div className="services-detail__section">
+                  <Text weight="semibold">Renewal path</Text>
+                  <Text>{renewalWindowLabel(selectedService.renewalDate, REFERENCE_DATE)}</Text>
+                  <Button
+                    size="small"
+                    appearance="secondary"
+                    onClick={() => openAlert(selectedService.id)}
+                  >
+                    Open related alert
+                  </Button>
+                </div>
+              ) : null}
+
+              {detailTab === "replacement" ? (
+                <div className="services-detail__section">
+                  <Text weight="semibold">Replacement planning</Text>
+                  <Text>{`Current stage: ${selectedService.replacementStatus}`}</Text>
+                  <Button
+                    size="small"
+                    appearance="secondary"
+                    onClick={() => openReplacement(selectedService.id)}
+                  >
+                    Open replacement workspace
+                  </Button>
+                </div>
+              ) : null}
+            </Card>
+          ) : (
+            <EmptyState
+              title="No service selected"
+              description="Select a service row to inspect lifecycle and linked context."
+            />
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/apps/renderer/src/features/services/service-contract-data.ts
+++ b/apps/renderer/src/features/services/service-contract-data.ts
@@ -1,0 +1,190 @@
+export type ServiceRisk = "low" | "medium" | "high";
+export type ServiceReplacementStatus =
+  | "not-started"
+  | "candidate-review"
+  | "approved";
+export type ContractLifecycleStatus =
+  | "active"
+  | "renewal-window"
+  | "notice-window"
+  | "expired";
+
+export type ServiceExpenseLine = {
+  id: string;
+  name: string;
+  amountMinor: number;
+  status: "planned" | "approved" | "committed" | "actual";
+};
+
+export type ServiceRecord = {
+  id: string;
+  name: string;
+  vendorName: string;
+  owner: string;
+  annualSpendMinor: number;
+  renewalDate: string;
+  risk: ServiceRisk;
+  replacementStatus: ServiceReplacementStatus;
+  linkedContractIds: string[];
+  expenseLines: ServiceExpenseLine[];
+};
+
+export type ContractRecord = {
+  id: string;
+  contractNumber: string;
+  providerName: string;
+  owner: string;
+  startDate: string;
+  endDate: string;
+  renewalDate: string;
+  noticeDeadline: string;
+  lifecycleStatus: ContractLifecycleStatus;
+  renewalAction: "auto-renew" | "manual-review" | "cancel-window";
+  linkedServiceIds: string[];
+  totalCommitmentMinor: number;
+};
+
+export const SERVICE_RECORDS: ServiceRecord[] = [
+  {
+    id: "svc-identity-sso",
+    name: "Identity SSO",
+    vendorName: "Okta",
+    owner: "IT Operations",
+    annualSpendMinor: 1820000,
+    renewalDate: "2026-04-20",
+    risk: "high",
+    replacementStatus: "candidate-review",
+    linkedContractIds: ["ctr-sso-main", "ctr-sso-addon"],
+    expenseLines: [
+      {
+        id: "exp-sso-1",
+        name: "Workforce IdP",
+        amountMinor: 1200000,
+        status: "approved"
+      },
+      {
+        id: "exp-sso-2",
+        name: "Adaptive MFA",
+        amountMinor: 620000,
+        status: "committed"
+      }
+    ]
+  },
+  {
+    id: "svc-cloud-platform",
+    name: "Cloud Platform",
+    vendorName: "AWS",
+    owner: "Platform Engineering",
+    annualSpendMinor: 5240000,
+    renewalDate: "2026-07-15",
+    risk: "medium",
+    replacementStatus: "not-started",
+    linkedContractIds: ["ctr-cloud-ops", "ctr-observability"],
+    expenseLines: [
+      {
+        id: "exp-cloud-1",
+        name: "Compute baseline",
+        amountMinor: 3420000,
+        status: "actual"
+      },
+      {
+        id: "exp-cloud-2",
+        name: "Reserved capacity",
+        amountMinor: 1820000,
+        status: "approved"
+      }
+    ]
+  },
+  {
+    id: "svc-endpoint-security",
+    name: "Endpoint Security",
+    vendorName: "Microsoft",
+    owner: "Security Team",
+    annualSpendMinor: 1310000,
+    renewalDate: "2026-03-25",
+    risk: "high",
+    replacementStatus: "candidate-review",
+    linkedContractIds: ["ctr-cloud-ops"],
+    expenseLines: [
+      {
+        id: "exp-endpoint-1",
+        name: "Defender Plan 2",
+        amountMinor: 980000,
+        status: "approved"
+      },
+      {
+        id: "exp-endpoint-2",
+        name: "Threat analytics add-on",
+        amountMinor: 330000,
+        status: "planned"
+      }
+    ]
+  }
+];
+
+export const CONTRACT_RECORDS: ContractRecord[] = [
+  {
+    id: "ctr-sso-main",
+    contractNumber: "CTR-SSO-001",
+    providerName: "Okta",
+    owner: "IT Operations",
+    startDate: "2025-04-21",
+    endDate: "2026-04-20",
+    renewalDate: "2026-04-20",
+    noticeDeadline: "2026-03-20",
+    lifecycleStatus: "notice-window",
+    renewalAction: "manual-review",
+    linkedServiceIds: ["svc-identity-sso"],
+    totalCommitmentMinor: 1200000
+  },
+  {
+    id: "ctr-sso-addon",
+    contractNumber: "CTR-SSO-ADD-02",
+    providerName: "Okta",
+    owner: "IT Operations",
+    startDate: "2025-06-01",
+    endDate: "2026-06-01",
+    renewalDate: "2026-06-01",
+    noticeDeadline: "2026-05-02",
+    lifecycleStatus: "renewal-window",
+    renewalAction: "manual-review",
+    linkedServiceIds: ["svc-identity-sso"],
+    totalCommitmentMinor: 620000
+  },
+  {
+    id: "ctr-cloud-ops",
+    contractNumber: "CTR-CLOUD-OPS-07",
+    providerName: "AWS",
+    owner: "Platform Engineering",
+    startDate: "2025-07-16",
+    endDate: "2026-07-15",
+    renewalDate: "2026-07-15",
+    noticeDeadline: "2026-06-15",
+    lifecycleStatus: "active",
+    renewalAction: "auto-renew",
+    linkedServiceIds: ["svc-cloud-platform", "svc-endpoint-security"],
+    totalCommitmentMinor: 4380000
+  },
+  {
+    id: "ctr-observability",
+    contractNumber: "CTR-OBS-004",
+    providerName: "Datadog",
+    owner: "Platform Engineering",
+    startDate: "2025-08-01",
+    endDate: "2026-08-01",
+    renewalDate: "2026-08-01",
+    noticeDeadline: "2026-07-02",
+    lifecycleStatus: "active",
+    renewalAction: "manual-review",
+    linkedServiceIds: ["svc-cloud-platform"],
+    totalCommitmentMinor: 860000
+  }
+];
+
+export const SERVICE_BY_ID: Record<string, ServiceRecord> = Object.fromEntries(
+  SERVICE_RECORDS.map((service) => [service.id, service])
+);
+
+export const CONTRACT_BY_ID: Record<string, ContractRecord> = Object.fromEntries(
+  CONTRACT_RECORDS.map((contract) => [contract.id, contract])
+);

--- a/apps/renderer/src/features/services/service-lifecycle-model.test.ts
+++ b/apps/renderer/src/features/services/service-lifecycle-model.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveServiceLifecycleState,
+  isInRenewalWindow,
+  renewalWindowLabel,
+  serviceLifecycleTone,
+  serviceRiskTone
+} from "./service-lifecycle-model";
+
+describe("service lifecycle model", () => {
+  it("maps lifecycle and risk statuses to expected chip tones", () => {
+    expect(serviceRiskTone("low")).toBe("success");
+    expect(serviceRiskTone("medium")).toBe("warning");
+    expect(serviceRiskTone("high")).toBe("danger");
+
+    expect(serviceLifecycleTone("healthy")).toBe("success");
+    expect(serviceLifecycleTone("renewal-window")).toBe("warning");
+    expect(serviceLifecycleTone("notice-window")).toBe("warning");
+    expect(serviceLifecycleTone("expired")).toBe("danger");
+  });
+
+  it("applies renewal window and lifecycle boundaries deterministically", () => {
+    const referenceDate = "2026-03-01";
+
+    expect(isInRenewalWindow("2026-04-30", referenceDate, 60)).toBe(true);
+    expect(isInRenewalWindow("2026-05-01", referenceDate, 60)).toBe(false);
+    expect(isInRenewalWindow("2026-02-28", referenceDate, 60)).toBe(false);
+
+    expect(
+      deriveServiceLifecycleState("2026-03-15", "low", referenceDate)
+    ).toBe("notice-window");
+    expect(
+      deriveServiceLifecycleState("2026-02-20", "high", referenceDate)
+    ).toBe("expired");
+    expect(
+      deriveServiceLifecycleState("2026-09-01", "low", referenceDate)
+    ).toBe("healthy");
+
+    expect(renewalWindowLabel("2026-03-01", referenceDate)).toBe("Renews today");
+  });
+});

--- a/apps/renderer/src/features/services/service-lifecycle-model.ts
+++ b/apps/renderer/src/features/services/service-lifecycle-model.ts
@@ -1,0 +1,86 @@
+import type {
+  ContractLifecycleStatus,
+  ServiceRisk
+} from "./service-contract-data";
+
+type StatusTone = "success" | "warning" | "danger" | "info";
+type ServiceLifecycleState = "healthy" | "renewal-window" | "notice-window" | "expired";
+
+function parseUtcDate(isoDate: string): Date {
+  return new Date(`${isoDate}T00:00:00.000Z`);
+}
+
+export function daysUntilDate(targetIsoDate: string, referenceIsoDate: string): number {
+  const target = parseUtcDate(targetIsoDate).getTime();
+  const reference = parseUtcDate(referenceIsoDate).getTime();
+  return Math.round((target - reference) / (1000 * 60 * 60 * 24));
+}
+
+export function isInRenewalWindow(
+  renewalIsoDate: string,
+  referenceIsoDate: string,
+  windowDays = 60
+): boolean {
+  const daysUntilRenewal = daysUntilDate(renewalIsoDate, referenceIsoDate);
+  return daysUntilRenewal >= 0 && daysUntilRenewal <= windowDays;
+}
+
+export function deriveServiceLifecycleState(
+  renewalIsoDate: string,
+  risk: ServiceRisk,
+  referenceIsoDate: string
+): ServiceLifecycleState {
+  const daysUntilRenewal = daysUntilDate(renewalIsoDate, referenceIsoDate);
+
+  if (daysUntilRenewal < 0) {
+    return "expired";
+  }
+  if (daysUntilRenewal <= 30) {
+    return "notice-window";
+  }
+  if (daysUntilRenewal <= 90 || risk === "high") {
+    return "renewal-window";
+  }
+  return "healthy";
+}
+
+export function serviceLifecycleTone(state: ServiceLifecycleState): StatusTone {
+  if (state === "expired") {
+    return "danger";
+  }
+  if (state === "notice-window" || state === "renewal-window") {
+    return "warning";
+  }
+  return "success";
+}
+
+export function serviceRiskTone(risk: ServiceRisk): StatusTone {
+  if (risk === "high") {
+    return "danger";
+  }
+  if (risk === "medium") {
+    return "warning";
+  }
+  return "success";
+}
+
+export function contractLifecycleTone(status: ContractLifecycleStatus): StatusTone {
+  if (status === "expired") {
+    return "danger";
+  }
+  if (status === "notice-window" || status === "renewal-window") {
+    return "warning";
+  }
+  return "info";
+}
+
+export function renewalWindowLabel(renewalIsoDate: string, referenceIsoDate: string): string {
+  const daysUntilRenewal = daysUntilDate(renewalIsoDate, referenceIsoDate);
+  if (daysUntilRenewal < 0) {
+    return `${Math.abs(daysUntilRenewal)} day(s) overdue`;
+  }
+  if (daysUntilRenewal === 0) {
+    return "Renews today";
+  }
+  return `${daysUntilRenewal} day(s) to renewal`;
+}


### PR DESCRIPTION
## Summary\n- replace Services and Contracts placeholder pages with lifecycle-focused workspaces\n- add shared service/contract fixtures and lifecycle model helpers (renewal windows + chip tone mapping)\n- add service detail tabs (Overview, Expenses, Contracts, Renewals, Replacement Plan) with cross-links\n- add contract detail with linked services, renewal review action, and alert/replacement navigation paths\n- add integration/e2e-style navigation coverage for service -> contract -> alert/replacement flows\n\n## Tests\n- npm run lint --workspace @budgetit/renderer\n- npm run typecheck --workspace @budgetit/renderer\n- npm run test --workspace @budgetit/renderer\n- npm run build --workspace @budgetit/renderer\n\nCloses #62