### PR TITLE
feat(ui): implement U7 vendors workspace

### DIFF
--- a/apps/renderer/src/features/services/ServicesPage.css
+++ b/apps/renderer/src/features/services/ServicesPage.css
@@ -7,7 +7,7 @@
   align-items: center;
   display: grid;
   gap: 0.75rem;
-  grid-template-columns: 1fr minmax(160px, 220px);
+  grid-template-columns: 1fr minmax(160px, 220px) minmax(160px, 220px);
 }
 
 .services-layout {

--- a/apps/renderer/src/features/services/service-contract-data.ts
+++ b/apps/renderer/src/features/services/service-contract-data.ts
@@ -18,6 +18,7 @@ export type ServiceExpenseLine = {
 
 export type ServiceRecord = {
   id: string;
+  vendorId: string;
   name: string;
   vendorName: string;
   owner: string;
@@ -31,6 +32,7 @@ export type ServiceRecord = {
 
 export type ContractRecord = {
   id: string;
+  vendorId: string;
   contractNumber: string;
   providerName: string;
   owner: string;
@@ -47,6 +49,7 @@ export type ContractRecord = {
 export const SERVICE_RECORDS: ServiceRecord[] = [
   {
     id: "svc-identity-sso",
+    vendorId: "vend-okta",
     name: "Identity SSO",
     vendorName: "Okta",
     owner: "IT Operations",
@@ -72,6 +75,7 @@ export const SERVICE_RECORDS: ServiceRecord[] = [
   },
   {
     id: "svc-cloud-platform",
+    vendorId: "vend-aws",
     name: "Cloud Platform",
     vendorName: "AWS",
     owner: "Platform Engineering",
@@ -97,6 +101,7 @@ export const SERVICE_RECORDS: ServiceRecord[] = [
   },
   {
     id: "svc-endpoint-security",
+    vendorId: "vend-msft",
     name: "Endpoint Security",
     vendorName: "Microsoft",
     owner: "Security Team",
@@ -125,6 +130,7 @@ export const SERVICE_RECORDS: ServiceRecord[] = [
 export const CONTRACT_RECORDS: ContractRecord[] = [
   {
     id: "ctr-sso-main",
+    vendorId: "vend-okta",
     contractNumber: "CTR-SSO-001",
     providerName: "Okta",
     owner: "IT Operations",
@@ -139,6 +145,7 @@ export const CONTRACT_RECORDS: ContractRecord[] = [
   },
   {
     id: "ctr-sso-addon",
+    vendorId: "vend-okta",
     contractNumber: "CTR-SSO-ADD-02",
     providerName: "Okta",
     owner: "IT Operations",
@@ -153,6 +160,7 @@ export const CONTRACT_RECORDS: ContractRecord[] = [
   },
   {
     id: "ctr-cloud-ops",
+    vendorId: "vend-aws",
     contractNumber: "CTR-CLOUD-OPS-07",
     providerName: "AWS",
     owner: "Platform Engineering",
@@ -167,6 +175,7 @@ export const CONTRACT_RECORDS: ContractRecord[] = [
   },
   {
     id: "ctr-observability",
+    vendorId: "vend-datadog",
     contractNumber: "CTR-OBS-004",
     providerName: "Datadog",
     owner: "Platform Engineering",

--- a/apps/renderer/src/features/vendors/VendorsPage.css
+++ b/apps/renderer/src/features/vendors/VendorsPage.css
@@ -1,0 +1,72 @@
+.vendors-page {
+  display: grid;
+  gap: 1rem;
+}
+
+.vendors-toolbar {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 420px);
+}
+
+.vendors-layout {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1.8fr) minmax(300px, 1fr);
+}
+
+.vendors-row--selected {
+  background: color-mix(in srgb, var(--colorNeutralBackground1) 70%, var(--colorBrandBackground) 30%);
+}
+
+.vendors-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.vendors-detail {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.vendors-detail__section {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.vendors-detail__list {
+  display: grid;
+  gap: 0.5rem;
+  list-style: disc;
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.vendors-linked-item {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+.vendors-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.vendors-form {
+  display: grid;
+  gap: 0.55rem;
+}
+
+@media (max-width: 1080px) {
+  .vendors-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .vendors-toolbar {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/renderer/src/features/vendors/VendorsPage.test.tsx
+++ b/apps/renderer/src/features/vendors/VendorsPage.test.tsx
@@ -1,0 +1,128 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AppShell } from "../../app/AppShell";
+import { AppRoutes } from "../../app/routes";
+import { budgetItLightTheme } from "../../ui/theme";
+
+function renderWorkspace(initialPath: string) {
+  return render(
+    <FluentProvider theme={budgetItLightTheme}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <AppShell>
+          <AppRoutes />
+        </AppShell>
+      </MemoryRouter>
+    </FluentProvider>
+  );
+}
+
+describe("VendorsPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows linked counts and applies vendor filters across services and expenses pages", async () => {
+    renderWorkspace("/vendors");
+
+    await screen.findByText("Vendors Workspace");
+    expect(screen.getByTestId("vendor-service-count-vend-aws")).toHaveTextContent("1");
+    expect(screen.getByTestId("vendor-contract-count-vend-aws")).toHaveTextContent("1");
+
+    const awsRow = screen.getByTestId("vendor-service-count-vend-aws").closest("tr");
+    if (!awsRow) {
+      throw new Error("Expected AWS vendor row.");
+    }
+
+    fireEvent.click(within(awsRow).getByRole("button", { name: "Open services" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Services");
+    });
+    const servicesTable = screen.getByRole("table", { name: "Services table" });
+    expect(within(servicesTable).getByText("Cloud Platform")).toBeInTheDocument();
+    expect(within(servicesTable).queryByText("Identity SSO")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("link", { name: "Vendors" }));
+    await screen.findByText("Vendors Workspace");
+
+    const awsRowAgain = screen.getByTestId("vendor-service-count-vend-aws").closest("tr");
+    if (!awsRowAgain) {
+      throw new Error("Expected AWS vendor row after returning to vendors.");
+    }
+    fireEvent.click(within(awsRowAgain).getByRole("button", { name: "Open expenses" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Expenses");
+    });
+    const expensesTable = screen.getByRole("table", { name: "Expenses table" });
+    expect(within(expensesTable).getByText("Cloud Compute")).toBeInTheDocument();
+    expect(within(expensesTable).queryByText("Endpoint Security")).not.toBeInTheDocument();
+  });
+
+  it("supports create+attach workflow and blocks unsafe delete while allowing archive", async () => {
+    renderWorkspace("/vendors");
+
+    await screen.findByText("Vendors Workspace");
+    fireEvent.click(screen.getByRole("button", { name: "Create Vendor" }));
+
+    fireEvent.change(screen.getByLabelText("Vendor name"), {
+      target: { value: "Acme Security" }
+    });
+    fireEvent.change(screen.getByLabelText("Vendor owner"), {
+      target: { value: "Security Operations" }
+    });
+    fireEvent.change(screen.getByLabelText("Vendor annual spend minor units"), {
+      target: { value: "50000" }
+    });
+    fireEvent.change(screen.getByLabelText("Vendor linked service IDs"), {
+      target: { value: "svc-cloud-platform" }
+    });
+
+    const createButtons = screen.getAllByRole("button", { name: "Create" });
+    fireEvent.click(createButtons[createButtons.length - 1]);
+    expect(await screen.findByText("Vendor Acme Security created.")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("vendor-service-count-vend-acme-security")
+    ).toHaveTextContent("1");
+
+    const acmeRow = screen
+      .getByTestId("vendor-service-count-vend-acme-security")
+      .closest("tr");
+    if (!acmeRow) {
+      throw new Error("Expected Acme Security vendor row.");
+    }
+
+    fireEvent.click(within(acmeRow).getByRole("button", { name: "Delete" }));
+    expect(
+      await screen.findByText("Cannot delete vendor while linked services or contracts exist.")
+    ).toBeInTheDocument();
+
+    fireEvent.click(within(acmeRow).getByRole("button", { name: "Archive" }));
+    const archiveDialog = await screen.findByRole("dialog");
+    fireEvent.click(
+      within(archiveDialog).getByRole("button", { name: "Archive", hidden: true })
+    );
+
+    expect(await screen.findByText("Vendor Acme Security archived.")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open service Cloud Platform" })
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Services");
+    });
+    const servicesTable = screen.getByRole("table", { name: "Services table" });
+    expect(within(servicesTable).getByText("Cloud Platform")).toBeInTheDocument();
+  });
+});

--- a/apps/renderer/src/features/vendors/VendorsPage.tsx
+++ b/apps/renderer/src/features/vendors/VendorsPage.tsx
@@ -1,11 +1,667 @@
-import { FeaturePlaceholderPage } from "../common/FeaturePlaceholderPage";
+import { useMemo, useState } from "react";
+import {
+  Button,
+  Card,
+  Input,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Text,
+  Title3
+} from "@fluentui/react-components";
+import { useNavigate } from "react-router-dom";
 
-export function VendorsPage() {
-  return (
-    <FeaturePlaceholderPage
-      title="Vendors"
-      description="Vendors workspace with robust CRUD, relationship visibility, and guarded archive/delete flows is planned in U7."
-    />
-  );
+import {
+  ConfirmDialog,
+  EmptyState,
+  FormDrawer,
+  InlineError,
+  PageHeader,
+  StatusChip
+} from "../../ui/primitives";
+import { CONTRACT_BY_ID, SERVICE_BY_ID } from "../services/service-contract-data";
+import {
+  INITIAL_VENDOR_RECORDS,
+  type VendorRecord,
+  type VendorRisk,
+  type VendorStatus
+} from "./vendor-data";
+import { evaluateVendorGuards, isDuplicateVendorName } from "./vendors-model";
+import "./VendorsPage.css";
+
+type VendorSortKey = "name" | "spend" | "status";
+type SortDirection = "asc" | "desc";
+
+type VendorFormState = {
+  name: string;
+  owner: string;
+  annualSpendMinor: string;
+  status: VendorStatus;
+  risk: VendorRisk;
+  linkedServiceIdsCsv: string;
+  linkedContractIdsCsv: string;
+};
+
+function createDefaultFormState(): VendorFormState {
+  return {
+    name: "",
+    owner: "",
+    annualSpendMinor: "0",
+    status: "active",
+    risk: "low",
+    linkedServiceIdsCsv: "",
+    linkedContractIdsCsv: ""
+  };
 }
 
+function fromVendor(vendor: VendorRecord): VendorFormState {
+  return {
+    name: vendor.name,
+    owner: vendor.owner,
+    annualSpendMinor: String(vendor.annualSpendMinor),
+    status: vendor.status,
+    risk: vendor.risk,
+    linkedServiceIdsCsv: vendor.linkedServiceIds.join(","),
+    linkedContractIdsCsv: vendor.linkedContractIds.join(",")
+  };
+}
+
+function formatUsd(amountMinor: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD"
+  }).format(amountMinor / 100);
+}
+
+function parseCsvIds(value: string): string[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function compareVendor(
+  left: VendorRecord,
+  right: VendorRecord,
+  sortKey: VendorSortKey,
+  direction: SortDirection
+): number {
+  const multiplier = direction === "asc" ? 1 : -1;
+  if (sortKey === "spend") {
+    return (left.annualSpendMinor - right.annualSpendMinor) * multiplier;
+  }
+  if (sortKey === "status") {
+    return left.status.localeCompare(right.status) * multiplier;
+  }
+  return left.name.localeCompare(right.name) * multiplier;
+}
+
+function statusTone(status: VendorStatus): "info" | "warning" | "success" {
+  if (status === "archived") {
+    return "warning";
+  }
+  if (status === "watch") {
+    return "info";
+  }
+  return "success";
+}
+
+function riskTone(risk: VendorRisk): "info" | "warning" | "danger" {
+  if (risk === "high") {
+    return "danger";
+  }
+  if (risk === "medium") {
+    return "warning";
+  }
+  return "info";
+}
+
+function normalizeVendorId(name: string): string {
+  return `vend-${name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")}`;
+}
+
+export function VendorsPage() {
+  const navigate = useNavigate();
+  const [vendors, setVendors] = useState<VendorRecord[]>(INITIAL_VENDOR_RECORDS);
+  const [searchText, setSearchText] = useState("");
+  const [sortKey, setSortKey] = useState<VendorSortKey>("name");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+  const [selectedVendorId, setSelectedVendorId] = useState<string>(
+    INITIAL_VENDOR_RECORDS[0]?.id ?? ""
+  );
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [drawerMode, setDrawerMode] = useState<"create" | "edit">("create");
+  const [editingVendorId, setEditingVendorId] = useState<string | null>(null);
+  const [formState, setFormState] = useState<VendorFormState>(createDefaultFormState());
+  const [formError, setFormError] = useState<string | null>(null);
+  const [archiveVendorId, setArchiveVendorId] = useState<string | null>(null);
+  const [deleteVendorId, setDeleteVendorId] = useState<string | null>(null);
+  const [pageMessage, setPageMessage] = useState<string | null>(null);
+
+  const filteredVendors = useMemo(() => {
+    const query = searchText.trim().toLowerCase();
+    return vendors
+      .filter((vendor) => {
+        if (!query) {
+          return true;
+        }
+        return (
+          vendor.name.toLowerCase().includes(query) ||
+          vendor.owner.toLowerCase().includes(query) ||
+          vendor.status.toLowerCase().includes(query)
+        );
+      })
+      .sort((left, right) => compareVendor(left, right, sortKey, sortDirection));
+  }, [searchText, sortDirection, sortKey, vendors]);
+
+  const selectedVendor =
+    filteredVendors.find((vendor) => vendor.id === selectedVendorId) ??
+    filteredVendors[0] ??
+    null;
+
+  function toggleSort(nextSortKey: VendorSortKey): void {
+    if (sortKey === nextSortKey) {
+      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortKey(nextSortKey);
+    setSortDirection("asc");
+  }
+
+  function openCreateDrawer(): void {
+    setDrawerMode("create");
+    setEditingVendorId(null);
+    setFormState(createDefaultFormState());
+    setFormError(null);
+    setDrawerOpen(true);
+  }
+
+  function openEditDrawer(vendor: VendorRecord): void {
+    setDrawerMode("edit");
+    setEditingVendorId(vendor.id);
+    setFormState(fromVendor(vendor));
+    setFormError(null);
+    setDrawerOpen(true);
+  }
+
+  function openServices(vendor: VendorRecord): void {
+    navigate(`/services?vendor=${vendor.id}`);
+  }
+
+  function openExpenses(vendor: VendorRecord): void {
+    navigate(`/expenses?vendor=${vendor.id}`);
+  }
+
+  function handleSubmitDrawer(): void {
+    const trimmedName = formState.name.trim();
+    const trimmedOwner = formState.owner.trim();
+    const annualSpendMinor = Number.parseInt(formState.annualSpendMinor, 10);
+    const linkedServiceIds = parseCsvIds(formState.linkedServiceIdsCsv);
+    const linkedContractIds = parseCsvIds(formState.linkedContractIdsCsv);
+
+    if (!trimmedName) {
+      setFormError("Vendor name is required.");
+      return;
+    }
+    if (!trimmedOwner) {
+      setFormError("Vendor owner is required.");
+      return;
+    }
+    if (Number.isNaN(annualSpendMinor) || annualSpendMinor < 0) {
+      setFormError("Annual spend (minor units) must be zero or a positive integer.");
+      return;
+    }
+    if (isDuplicateVendorName(trimmedName, vendors, editingVendorId ?? undefined)) {
+      setFormError("Vendor name already exists.");
+      return;
+    }
+    if (linkedServiceIds.some((serviceId) => !SERVICE_BY_ID[serviceId])) {
+      setFormError("One or more linked service IDs are invalid.");
+      return;
+    }
+    if (linkedContractIds.some((contractId) => !CONTRACT_BY_ID[contractId])) {
+      setFormError("One or more linked contract IDs are invalid.");
+      return;
+    }
+
+    const nextVendor: VendorRecord = {
+      id: editingVendorId ?? normalizeVendorId(trimmedName),
+      name: trimmedName,
+      owner: trimmedOwner,
+      annualSpendMinor,
+      status: formState.status,
+      risk: formState.risk,
+      linkedServiceIds,
+      linkedContractIds
+    };
+
+    setVendors((current) => {
+      if (drawerMode === "create") {
+        return [...current, nextVendor];
+      }
+      return current.map((vendor) =>
+        vendor.id === nextVendor.id ? nextVendor : vendor
+      );
+    });
+    setSelectedVendorId(nextVendor.id);
+    setDrawerOpen(false);
+    setFormError(null);
+    setPageMessage(
+      drawerMode === "create"
+        ? `Vendor ${nextVendor.name} created.`
+        : `Vendor ${nextVendor.name} updated.`
+    );
+  }
+
+  function requestArchive(vendor: VendorRecord): void {
+    const guard = evaluateVendorGuards(vendor);
+    if (!guard.canArchive) {
+      setPageMessage(guard.archiveReason);
+      return;
+    }
+    setArchiveVendorId(vendor.id);
+  }
+
+  function confirmArchive(): void {
+    if (!archiveVendorId) {
+      return;
+    }
+    setVendors((current) =>
+      current.map((vendor) =>
+        vendor.id === archiveVendorId ? { ...vendor, status: "archived" } : vendor
+      )
+    );
+    const vendorName =
+      vendors.find((vendor) => vendor.id === archiveVendorId)?.name ?? archiveVendorId;
+    setPageMessage(`Vendor ${vendorName} archived.`);
+    setArchiveVendorId(null);
+  }
+
+  function requestDelete(vendor: VendorRecord): void {
+    const guard = evaluateVendorGuards(vendor);
+    if (!guard.canDelete) {
+      setPageMessage(guard.deleteReason);
+      return;
+    }
+    setDeleteVendorId(vendor.id);
+  }
+
+  function confirmDelete(): void {
+    if (!deleteVendorId) {
+      return;
+    }
+    const deletedVendorName =
+      vendors.find((vendor) => vendor.id === deleteVendorId)?.name ?? deleteVendorId;
+    setVendors((current) => current.filter((vendor) => vendor.id !== deleteVendorId));
+    if (selectedVendorId === deleteVendorId) {
+      setSelectedVendorId("");
+    }
+    setPageMessage(`Vendor ${deletedVendorName} deleted.`);
+    setDeleteVendorId(null);
+  }
+
+  return (
+    <section className="vendors-page">
+      <PageHeader
+        title="Vendors Workspace"
+        subtitle="Manage vendor lifecycle, relationship impact, and guarded archive/delete workflows."
+        actions={
+          <Button appearance="primary" onClick={openCreateDrawer}>
+            Create Vendor
+          </Button>
+        }
+      />
+
+      <div className="vendors-toolbar">
+        <Input
+          aria-label="Search vendors"
+          placeholder="Search by name, owner, or status"
+          value={searchText}
+          onChange={(_event, data) => setSearchText(data.value)}
+        />
+      </div>
+
+      {pageMessage ? <Text>{pageMessage}</Text> : null}
+
+      <div className="vendors-layout">
+        <section>
+          {filteredVendors.length === 0 ? (
+            <EmptyState
+              title="No vendors match filters"
+              description="Adjust search terms or create a vendor to populate this workspace."
+            />
+          ) : (
+            <Table aria-label="Vendors table">
+              <TableHeader>
+                <TableRow>
+                  <TableHeaderCell>
+                    <Button size="small" appearance="subtle" onClick={() => toggleSort("name")}>
+                      Name
+                    </Button>
+                  </TableHeaderCell>
+                  <TableHeaderCell>Owner</TableHeaderCell>
+                  <TableHeaderCell>
+                    <Button size="small" appearance="subtle" onClick={() => toggleSort("spend")}>
+                      Annual spend
+                    </Button>
+                  </TableHeaderCell>
+                  <TableHeaderCell>
+                    <Button size="small" appearance="subtle" onClick={() => toggleSort("status")}>
+                      Status
+                    </Button>
+                  </TableHeaderCell>
+                  <TableHeaderCell>Risk</TableHeaderCell>
+                  <TableHeaderCell>Linked services</TableHeaderCell>
+                  <TableHeaderCell>Linked contracts</TableHeaderCell>
+                  <TableHeaderCell>Actions</TableHeaderCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredVendors.map((vendor) => {
+                  const selected = selectedVendor?.id === vendor.id;
+                  return (
+                    <TableRow
+                      key={vendor.id}
+                      className={selected ? "vendors-row vendors-row--selected" : "vendors-row"}
+                      onClick={() => setSelectedVendorId(vendor.id)}
+                    >
+                      <TableCell>{vendor.name}</TableCell>
+                      <TableCell>{vendor.owner}</TableCell>
+                      <TableCell>{formatUsd(vendor.annualSpendMinor)}</TableCell>
+                      <TableCell>
+                        <StatusChip label={vendor.status.toUpperCase()} tone={statusTone(vendor.status)} />
+                      </TableCell>
+                      <TableCell>
+                        <StatusChip label={vendor.risk.toUpperCase()} tone={riskTone(vendor.risk)} />
+                      </TableCell>
+                      <TableCell data-testid={`vendor-service-count-${vendor.id}`}>
+                        {vendor.linkedServiceIds.length}
+                      </TableCell>
+                      <TableCell data-testid={`vendor-contract-count-${vendor.id}`}>
+                        {vendor.linkedContractIds.length}
+                      </TableCell>
+                      <TableCell>
+                        <div className="vendors-row__actions">
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setSelectedVendorId(vendor.id);
+                            }}
+                          >
+                            Review
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openEditDrawer(vendor);
+                            }}
+                          >
+                            Edit
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openServices(vendor);
+                            }}
+                          >
+                            Open services
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              openExpenses(vendor);
+                            }}
+                          >
+                            Open expenses
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              requestArchive(vendor);
+                            }}
+                          >
+                            Archive
+                          </Button>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              requestDelete(vendor);
+                            }}
+                          >
+                            Delete
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </section>
+
+        <aside>
+          {selectedVendor ? (
+            <Card className="vendors-detail">
+              <Title3>{selectedVendor.name}</Title3>
+              <Text>{`Owner: ${selectedVendor.owner}`}</Text>
+              <Text>{`Annual spend: ${formatUsd(selectedVendor.annualSpendMinor)}`}</Text>
+              <Text>{`Status: ${selectedVendor.status}`}</Text>
+              <Text>{`Risk: ${selectedVendor.risk}`}</Text>
+
+              <div className="vendors-detail__section">
+                <Text weight="semibold">Linked services</Text>
+                <ul className="vendors-detail__list">
+                  {selectedVendor.linkedServiceIds.length === 0 ? (
+                    <li>
+                      <Text>No linked services.</Text>
+                    </li>
+                  ) : (
+                    selectedVendor.linkedServiceIds.map((serviceId) => {
+                      const service = SERVICE_BY_ID[serviceId];
+                      if (!service) {
+                        return null;
+                      }
+                      return (
+                        <li key={service.id} className="vendors-linked-item">
+                          <Text>{service.name}</Text>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={() =>
+                              navigate(`/services?service=${service.id}&tab=overview`)
+                            }
+                          >
+                            {`Open service ${service.name}`}
+                          </Button>
+                        </li>
+                      );
+                    })
+                  )}
+                </ul>
+              </div>
+
+              <div className="vendors-detail__section">
+                <Text weight="semibold">Linked contracts</Text>
+                <ul className="vendors-detail__list">
+                  {selectedVendor.linkedContractIds.length === 0 ? (
+                    <li>
+                      <Text>No linked contracts.</Text>
+                    </li>
+                  ) : (
+                    selectedVendor.linkedContractIds.map((contractId) => {
+                      const contract = CONTRACT_BY_ID[contractId];
+                      if (!contract) {
+                        return null;
+                      }
+                      return (
+                        <li key={contract.id} className="vendors-linked-item">
+                          <Text>{contract.contractNumber}</Text>
+                          <Button
+                            size="small"
+                            appearance="secondary"
+                            onClick={() => navigate(`/contracts?contract=${contract.id}`)}
+                          >
+                            {`Open contract ${contract.contractNumber}`}
+                          </Button>
+                        </li>
+                      );
+                    })
+                  )}
+                </ul>
+              </div>
+
+              <div className="vendors-detail__actions">
+                <Button
+                  size="small"
+                  appearance="secondary"
+                  onClick={() => openServices(selectedVendor)}
+                >
+                  Open services workspace
+                </Button>
+                <Button
+                  size="small"
+                  appearance="secondary"
+                  onClick={() => openExpenses(selectedVendor)}
+                >
+                  Open expenses workspace
+                </Button>
+              </div>
+            </Card>
+          ) : (
+            <EmptyState
+              title="No vendor selected"
+              description="Select a vendor row to inspect relationship impact."
+            />
+          )}
+        </aside>
+      </div>
+
+      <FormDrawer
+        open={drawerOpen}
+        title={drawerMode === "create" ? "Create Vendor" : "Edit Vendor"}
+        onOpenChange={setDrawerOpen}
+        onSubmit={handleSubmitDrawer}
+        submitLabel={drawerMode === "create" ? "Create" : "Save"}
+      >
+        <div className="vendors-form">
+          <Input
+            aria-label="Vendor name"
+            value={formState.name}
+            onChange={(_event, data) =>
+              setFormState((current) => ({ ...current, name: data.value }))
+            }
+            placeholder="Vendor name"
+          />
+          <Input
+            aria-label="Vendor owner"
+            value={formState.owner}
+            onChange={(_event, data) =>
+              setFormState((current) => ({ ...current, owner: data.value }))
+            }
+            placeholder="Vendor owner"
+          />
+          <Input
+            aria-label="Vendor annual spend minor units"
+            value={formState.annualSpendMinor}
+            onChange={(_event, data) =>
+              setFormState((current) => ({ ...current, annualSpendMinor: data.value }))
+            }
+            placeholder="Annual spend (minor units)"
+          />
+          <Select
+            aria-label="Vendor status"
+            value={formState.status}
+            onChange={(event) =>
+              setFormState((current) => ({
+                ...current,
+                status: event.target.value as VendorStatus
+              }))
+            }
+          >
+            <option value="active">active</option>
+            <option value="watch">watch</option>
+            <option value="archived">archived</option>
+          </Select>
+          <Select
+            aria-label="Vendor risk"
+            value={formState.risk}
+            onChange={(event) =>
+              setFormState((current) => ({
+                ...current,
+                risk: event.target.value as VendorRisk
+              }))
+            }
+          >
+            <option value="low">low</option>
+            <option value="medium">medium</option>
+            <option value="high">high</option>
+          </Select>
+          <Input
+            aria-label="Vendor linked service IDs"
+            value={formState.linkedServiceIdsCsv}
+            onChange={(_event, data) =>
+              setFormState((current) => ({ ...current, linkedServiceIdsCsv: data.value }))
+            }
+            placeholder="Linked service IDs (comma-separated)"
+          />
+          <Input
+            aria-label="Vendor linked contract IDs"
+            value={formState.linkedContractIdsCsv}
+            onChange={(_event, data) =>
+              setFormState((current) => ({ ...current, linkedContractIdsCsv: data.value }))
+            }
+            placeholder="Linked contract IDs (comma-separated)"
+          />
+        </div>
+        {formError ? <InlineError message={formError} /> : null}
+      </FormDrawer>
+
+      <ConfirmDialog
+        open={archiveVendorId !== null}
+        title="Archive vendor?"
+        message="Archive keeps linked records but removes this vendor from active workflow."
+        onOpenChange={(open) => {
+          if (!open) {
+            setArchiveVendorId(null);
+          }
+        }}
+        onConfirm={confirmArchive}
+        confirmLabel="Archive"
+      />
+
+      <ConfirmDialog
+        open={deleteVendorId !== null}
+        title="Delete vendor?"
+        message="Delete permanently removes the vendor record."
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteVendorId(null);
+          }
+        }}
+        onConfirm={confirmDelete}
+        confirmLabel="Delete"
+      />
+    </section>
+  );
+}

--- a/apps/renderer/src/features/vendors/vendor-data.ts
+++ b/apps/renderer/src/features/vendors/vendor-data.ts
@@ -1,0 +1,66 @@
+export type VendorStatus = "active" | "watch" | "archived";
+export type VendorRisk = "low" | "medium" | "high";
+
+export type VendorRecord = {
+  id: string;
+  name: string;
+  owner: string;
+  annualSpendMinor: number;
+  status: VendorStatus;
+  risk: VendorRisk;
+  linkedServiceIds: string[];
+  linkedContractIds: string[];
+};
+
+export const INITIAL_VENDOR_RECORDS: VendorRecord[] = [
+  {
+    id: "vend-okta",
+    name: "Okta",
+    owner: "IT Operations",
+    annualSpendMinor: 1820000,
+    status: "active",
+    risk: "high",
+    linkedServiceIds: ["svc-identity-sso"],
+    linkedContractIds: ["ctr-sso-main", "ctr-sso-addon"]
+  },
+  {
+    id: "vend-aws",
+    name: "AWS",
+    owner: "Platform Engineering",
+    annualSpendMinor: 5240000,
+    status: "active",
+    risk: "medium",
+    linkedServiceIds: ["svc-cloud-platform"],
+    linkedContractIds: ["ctr-cloud-ops"]
+  },
+  {
+    id: "vend-msft",
+    name: "Microsoft",
+    owner: "Security Team",
+    annualSpendMinor: 1310000,
+    status: "watch",
+    risk: "high",
+    linkedServiceIds: ["svc-endpoint-security"],
+    linkedContractIds: []
+  },
+  {
+    id: "vend-datadog",
+    name: "Datadog",
+    owner: "Platform Engineering",
+    annualSpendMinor: 860000,
+    status: "active",
+    risk: "medium",
+    linkedServiceIds: [],
+    linkedContractIds: ["ctr-observability"]
+  },
+  {
+    id: "vend-unused",
+    name: "Unused Supplier",
+    owner: "Finance Ops",
+    annualSpendMinor: 0,
+    status: "watch",
+    risk: "low",
+    linkedServiceIds: [],
+    linkedContractIds: []
+  }
+];

--- a/apps/renderer/src/features/vendors/vendor-filter-model.ts
+++ b/apps/renderer/src/features/vendors/vendor-filter-model.ts
@@ -1,0 +1,32 @@
+export type VendorFilterOption = {
+  value: string;
+  label: string;
+};
+
+export function buildVendorFilterOptions(
+  records: Array<{ vendorId: string; vendorName: string }>
+): VendorFilterOption[] {
+  const deduped = new Map<string, string>();
+  for (const record of records) {
+    if (!record.vendorId) {
+      continue;
+    }
+    if (!deduped.has(record.vendorId)) {
+      deduped.set(record.vendorId, record.vendorName);
+    }
+  }
+
+  return Array.from(deduped.entries())
+    .map(([value, label]) => ({ value, label }))
+    .sort((left, right) => left.label.localeCompare(right.label));
+}
+
+export function matchesVendorFilter(
+  selectedVendorId: string,
+  recordVendorId: string
+): boolean {
+  if (selectedVendorId === "all") {
+    return true;
+  }
+  return selectedVendorId === recordVendorId;
+}

--- a/apps/renderer/src/features/vendors/vendors-model.test.ts
+++ b/apps/renderer/src/features/vendors/vendors-model.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { INITIAL_VENDOR_RECORDS } from "./vendor-data";
+import { evaluateVendorGuards, isDuplicateVendorName } from "./vendors-model";
+
+describe("vendors model", () => {
+  it("detects duplicate vendor names with case-insensitive normalization", () => {
+    expect(isDuplicateVendorName("okta", INITIAL_VENDOR_RECORDS)).toBe(true);
+    expect(isDuplicateVendorName("  AWS  ", INITIAL_VENDOR_RECORDS)).toBe(true);
+    expect(
+      isDuplicateVendorName("okta", INITIAL_VENDOR_RECORDS, "vend-okta")
+    ).toBe(false);
+    expect(isDuplicateVendorName("New Vendor", INITIAL_VENDOR_RECORDS)).toBe(false);
+  });
+
+  it("applies archive/delete guard rules from dependency state", () => {
+    const activeWithDependencies = evaluateVendorGuards(INITIAL_VENDOR_RECORDS[0]);
+    expect(activeWithDependencies.canArchive).toBe(true);
+    expect(activeWithDependencies.canDelete).toBe(false);
+    expect(activeWithDependencies.deleteReason).toMatch(/Cannot delete vendor/i);
+
+    const archivedRecord = evaluateVendorGuards({
+      ...INITIAL_VENDOR_RECORDS[0],
+      status: "archived",
+      linkedServiceIds: [],
+      linkedContractIds: []
+    });
+    expect(archivedRecord.canArchive).toBe(false);
+    expect(archivedRecord.archiveReason).toMatch(/already archived/i);
+    expect(archivedRecord.canDelete).toBe(true);
+  });
+});

--- a/apps/renderer/src/features/vendors/vendors-model.ts
+++ b/apps/renderer/src/features/vendors/vendors-model.ts
@@ -1,0 +1,48 @@
+import type { VendorRecord } from "./vendor-data";
+
+export type VendorGuardResult = {
+  canArchive: boolean;
+  canDelete: boolean;
+  archiveReason: string | null;
+  deleteReason: string | null;
+};
+
+export function normalizeVendorName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+export function isDuplicateVendorName(
+  candidateName: string,
+  records: VendorRecord[],
+  excludedVendorId?: string
+): boolean {
+  const normalizedCandidate = normalizeVendorName(candidateName);
+  if (!normalizedCandidate) {
+    return false;
+  }
+  return records.some((record) => {
+    if (excludedVendorId && record.id === excludedVendorId) {
+      return false;
+    }
+    return normalizeVendorName(record.name) === normalizedCandidate;
+  });
+}
+
+export function evaluateVendorGuards(record: VendorRecord): VendorGuardResult {
+  const dependencyCount =
+    record.linkedServiceIds.length + record.linkedContractIds.length;
+
+  const canArchive = record.status !== "archived";
+  const canDelete = dependencyCount === 0;
+
+  return {
+    canArchive,
+    canDelete,
+    archiveReason: canArchive
+      ? null
+      : "Vendor is already archived.",
+    deleteReason: canDelete
+      ? null
+      : "Cannot delete vendor while linked services or contracts exist."
+  };
+}


### PR DESCRIPTION
## Summary\n- replace Vendors placeholder with full CRUD workspace (search/sort, detail pane, drawer forms, archive/delete guards)\n- add vendor relationship visibility (linked service/contract counts + quick navigation paths)\n- add vendor guard model for duplicate detection and archive/delete eligibility rules\n- add shared vendor filter model and wire vendor filtering into Services and Expenses pages\n- add integration/e2e tests for vendor cross-page filtering and guarded lifecycle actions\n\n## Tests\n- npm run lint --workspace @budgetit/renderer\n- npm run typecheck --workspace @budgetit/renderer\n- npm run test --workspace @budgetit/renderer\n- npm run build --workspace @budgetit/renderer\n\nCloses #63