### PR TITLE
[U9] Scenario management page and global scenario context selector

### DIFF
--- a/apps/renderer/src/app/AppShell.tsx
+++ b/apps/renderer/src/app/AppShell.tsx
@@ -2,12 +2,14 @@ import type { PropsWithChildren } from "react";
 import { Button, Input, Select, Text } from "@fluentui/react-components";
 import { NavLink, useLocation } from "react-router-dom";
 
+import { useScenarioContext } from "../features/scenarios/ScenarioContext";
 import { NAV_ROUTES, resolveRouteLabel } from "./routes";
 import "./AppShell.css";
 
 export function AppShell({ children }: PropsWithChildren) {
   const location = useLocation();
   const pageTitle = resolveRouteLabel(location.pathname);
+  const { scenarios, selectedScenarioId, selectScenario } = useScenarioContext();
 
   return (
     <div className="desktop-shell">
@@ -38,10 +40,17 @@ export function AppShell({ children }: PropsWithChildren) {
           >
             {pageTitle}
           </Text>
-          <Select aria-label="Scenario selector" className="desktop-shell__toolbar-select" defaultValue="baseline">
-            <option value="baseline">Baseline</option>
-            <option value="draft">Draft</option>
-            <option value="approved">Approved</option>
+          <Select
+            aria-label="Scenario selector"
+            className="desktop-shell__toolbar-select"
+            value={selectedScenarioId}
+            onChange={(event) => selectScenario(event.target.value)}
+          >
+            {scenarios.map((scenario) => (
+              <option key={scenario.id} value={scenario.id}>
+                {scenario.name}
+              </option>
+            ))}
           </Select>
           <Input
             aria-label="Global search"

--- a/apps/renderer/src/features/reports/ReportsPage.css
+++ b/apps/renderer/src/features/reports/ReportsPage.css
@@ -1,0 +1,18 @@
+.reports-page {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem 1.25rem;
+}
+
+.reports-page__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.reports-page__export-list {
+  margin: 0.3rem 0 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.15rem;
+}

--- a/apps/renderer/src/features/reports/ReportsPage.tsx
+++ b/apps/renderer/src/features/reports/ReportsPage.tsx
@@ -1,11 +1,188 @@
-import { FeaturePlaceholderPage } from "../common/FeaturePlaceholderPage";
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Card,
+  Menu,
+  MenuItem,
+  MenuList,
+  MenuPopover,
+  MenuTrigger,
+  Select,
+  Text,
+  Title3
+} from "@fluentui/react-components";
+
+import type { DashboardDataset } from "../../reporting";
+import { exportReport, queryReport } from "../../lib/ipcClient";
+import { EmptyState, InlineError, PageHeader } from "../../ui/primitives";
+import { useScenarioContext } from "../scenarios/ScenarioContext";
+import "./ReportsPage.css";
+
+type ReportFormat = "html" | "pdf" | "excel" | "csv" | "png";
+type ReportType = "dashboard.summary" | "renewals.timeline" | "variance.monthly";
+
+const REPORT_TYPES: Array<{ value: ReportType; label: string }> = [
+  { value: "dashboard.summary", label: "Dashboard Summary" },
+  { value: "renewals.timeline", label: "Renewals Timeline" },
+  { value: "variance.monthly", label: "Monthly Variance" }
+];
+
+const EXPORT_FORMATS: Array<{ value: ReportFormat; label: string }> = [
+  { value: "html", label: "Export HTML" },
+  { value: "pdf", label: "Export PDF" },
+  { value: "excel", label: "Export Excel" },
+  { value: "csv", label: "Export CSV" },
+  { value: "png", label: "Export PNG" }
+];
 
 export function ReportsPage() {
+  const { selectedScenarioId, selectedScenario } = useScenarioContext();
+  const [reportType, setReportType] = useState<ReportType>("dashboard.summary");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dataset, setDataset] = useState<DashboardDataset | null>(null);
+  const [exporting, setExporting] = useState<ReportFormat | null>(null);
+  const [exportFiles, setExportFiles] = useState<
+    Partial<Record<ReportFormat, string>>
+  >({});
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  async function loadReport(nextType: ReportType, scenarioId: string): Promise<void> {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = (await queryReport({
+        query: nextType,
+        scenarioId
+      })) as DashboardDataset;
+      setDataset(next);
+    } catch (nextError) {
+      const detail = nextError instanceof Error ? nextError.message : String(nextError);
+      setError(`Failed to load report dataset: ${detail}`);
+      setDataset(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadReport(reportType, selectedScenarioId);
+  }, [reportType, selectedScenarioId]);
+
+  async function handleExport(format: ReportFormat): Promise<void> {
+    setExporting(format);
+    setExportError(null);
+    try {
+      const result = await exportReport({
+        scenarioId: selectedScenarioId,
+        formats: [format],
+        reportType
+      });
+      setExportFiles(result.files);
+    } catch (nextError) {
+      const detail = nextError instanceof Error ? nextError.message : String(nextError);
+      setExportError(`Export failed: ${detail}`);
+    } finally {
+      setExporting(null);
+    }
+  }
+
   return (
-    <FeaturePlaceholderPage
-      title="Reports"
-      description="Report gallery and configurable reporting workspace with export orchestration are planned in U11."
-    />
+    <section className="reports-page">
+      <PageHeader
+        title="Reports Workspace"
+        subtitle={`Gallery and workspace controls with active scenario context: ${
+          selectedScenario?.name ?? selectedScenarioId
+        }.`}
+        actions={
+          <div className="reports-page__actions">
+            <Button
+              appearance="secondary"
+              onClick={() => void loadReport(reportType, selectedScenarioId)}
+              disabled={loading}
+            >
+              Refresh
+            </Button>
+            <Menu>
+              <MenuTrigger disableButtonEnhancement>
+                <Button appearance="primary" disabled={exporting !== null}>
+                  {exporting ? `Exporting ${exporting.toUpperCase()}...` : "Export"}
+                </Button>
+              </MenuTrigger>
+              <MenuPopover>
+                <MenuList>
+                  {EXPORT_FORMATS.map((entry) => (
+                    <MenuItem
+                      key={entry.value}
+                      disabled={exporting !== null}
+                      onClick={() => {
+                        void handleExport(entry.value);
+                      }}
+                    >
+                      {entry.label}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </MenuPopover>
+            </Menu>
+          </div>
+        }
+      />
+
+      <Card data-testid="reports-scenario-context">
+        <Text weight="semibold">Scenario context</Text>
+        <Text>{selectedScenario?.name ?? selectedScenarioId}</Text>
+      </Card>
+
+      <Card>
+        <Title3>Report Type</Title3>
+        <Select
+          aria-label="Report type"
+          value={reportType}
+          onChange={(event) => setReportType(event.target.value as ReportType)}
+        >
+          {REPORT_TYPES.map((entry) => (
+            <option key={entry.value} value={entry.value}>
+              {entry.label}
+            </option>
+          ))}
+        </Select>
+      </Card>
+
+      {error ? <InlineError message={error} /> : null}
+      {exportError ? <InlineError message={exportError} /> : null}
+
+      {Object.keys(exportFiles).length > 0 ? (
+        <Card data-testid="reports-export-metadata">
+          <Text weight="semibold">{`Export metadata: scenario ${selectedScenarioId}`}</Text>
+          <ul className="reports-page__export-list">
+            {Object.entries(exportFiles).map(([format, path]) => (
+              <li key={format}>
+                <Text>{`${format.toUpperCase()}: ${path}`}</Text>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      ) : null}
+
+      {loading ? (
+        <Card>
+          <Text>Loading report dataset...</Text>
+        </Card>
+      ) : !dataset ? (
+        <EmptyState
+          title="No report dataset available"
+          description="Select another report type or refresh this scenario context."
+        />
+      ) : (
+        <Card>
+          <Title3>{`Dataset snapshot (${dataset.scenarioId})`}</Title3>
+          <Text>{`Spend trend rows: ${dataset.spendTrend.length}`}</Text>
+          <Text>{`Variance rows: ${dataset.variance.length}`}</Text>
+          <Text>{`Renewal rows: ${dataset.renewals.length}`}</Text>
+        </Card>
+      )}
+    </section>
   );
 }
 

--- a/apps/renderer/src/features/scenarios/ScenarioContext.tsx
+++ b/apps/renderer/src/features/scenarios/ScenarioContext.tsx
@@ -1,0 +1,80 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  type PropsWithChildren
+} from "react";
+
+import {
+  DEFAULT_SCENARIO_STATE,
+  loadScenarioState,
+  persistScenarioState,
+  scenarioReducer,
+  type ScenarioRecord
+} from "./scenario-model";
+
+type ScenarioContextValue = {
+  scenarios: ScenarioRecord[];
+  selectedScenarioId: string;
+  selectedScenario: ScenarioRecord | null;
+  selectScenario: (scenarioId: string) => void;
+  cloneScenario: (sourceScenarioId: string) => void;
+  promoteScenario: (scenarioId: string) => void;
+  lockScenario: (scenarioId: string) => void;
+};
+
+const FALLBACK_VALUE: ScenarioContextValue = {
+  scenarios: DEFAULT_SCENARIO_STATE.scenarios,
+  selectedScenarioId: DEFAULT_SCENARIO_STATE.selectedScenarioId,
+  selectedScenario:
+    DEFAULT_SCENARIO_STATE.scenarios.find(
+      (scenario) => scenario.id === DEFAULT_SCENARIO_STATE.selectedScenarioId
+    ) ?? null,
+  selectScenario: () => undefined,
+  cloneScenario: () => undefined,
+  promoteScenario: () => undefined,
+  lockScenario: () => undefined
+};
+
+const ScenarioContext = createContext<ScenarioContextValue | null>(null);
+
+export function ScenarioProvider({ children }: PropsWithChildren) {
+  const [state, dispatch] = useReducer(scenarioReducer, undefined, () =>
+    loadScenarioState()
+  );
+
+  useEffect(() => {
+    persistScenarioState(state);
+  }, [state]);
+
+  const value = useMemo<ScenarioContextValue>(() => {
+    const selectedScenario =
+      state.scenarios.find((scenario) => scenario.id === state.selectedScenarioId) ?? null;
+
+    return {
+      scenarios: state.scenarios,
+      selectedScenarioId: state.selectedScenarioId,
+      selectedScenario,
+      selectScenario: (scenarioId) => {
+        dispatch({ type: "select", scenarioId });
+      },
+      cloneScenario: (sourceScenarioId) => {
+        dispatch({ type: "clone", sourceScenarioId });
+      },
+      promoteScenario: (scenarioId) => {
+        dispatch({ type: "promote", scenarioId });
+      },
+      lockScenario: (scenarioId) => {
+        dispatch({ type: "lock", scenarioId });
+      }
+    };
+  }, [state]);
+
+  return <ScenarioContext.Provider value={value}>{children}</ScenarioContext.Provider>;
+}
+
+export function useScenarioContext(): ScenarioContextValue {
+  return useContext(ScenarioContext) ?? FALLBACK_VALUE;
+}

--- a/apps/renderer/src/features/scenarios/ScenariosPage.css
+++ b/apps/renderer/src/features/scenarios/ScenariosPage.css
@@ -1,0 +1,21 @@
+.scenarios-page {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem 1.25rem;
+}
+
+.scenarios-page__summary {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.scenarios-page__row--selected {
+  outline: 2px solid #0b5fff;
+  outline-offset: -2px;
+}
+
+.scenarios-page__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}

--- a/apps/renderer/src/features/scenarios/ScenariosPage.test.tsx
+++ b/apps/renderer/src/features/scenarios/ScenariosPage.test.tsx
@@ -1,0 +1,158 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DashboardDataset } from "../../reporting";
+import { AppShell } from "../../app/AppShell";
+import { AppRoutes } from "../../app/routes";
+import { exportReport, queryReport } from "../../lib/ipcClient";
+import { budgetItLightTheme } from "../../ui/theme";
+import { ScenarioProvider } from "./ScenarioContext";
+
+vi.mock("../../lib/ipcClient", () => ({
+  queryReport: vi.fn(),
+  exportReport: vi.fn()
+}));
+
+const datasetFixture: DashboardDataset = {
+  scenarioId: "baseline",
+  staleForecast: false,
+  spendTrend: [{ month: "2026-01", forecastMinor: 10000, actualMinor: 9800 }],
+  variance: [
+    {
+      month: "2026-01",
+      forecastMinor: 10000,
+      actualMinor: 9800,
+      varianceMinor: -200,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    }
+  ],
+  renewals: [{ month: "2026-06", count: 1 }],
+  growth: [{ month: "2026-01", forecastMinor: 10000, growthPct: null }],
+  taggingCompleteness: {
+    totalExpenseLines: 10,
+    taggedExpenseLines: 9,
+    completenessRatio: 0.9
+  },
+  replacementStatus: {
+    totalPlans: 2,
+    replacementRequiredOpen: 1,
+    byStatus: [{ status: "draft", count: 2 }]
+  },
+  narrativeBlocks: [{ id: "summary", title: "Summary", body: "Context fixture" }]
+};
+
+const queryReportMock = vi.mocked(queryReport);
+const exportReportMock = vi.mocked(exportReport);
+
+function renderWorkspace(initialPath: string) {
+  return render(
+    <ScenarioProvider>
+      <FluentProvider theme={budgetItLightTheme}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <AppShell>
+            <AppRoutes />
+          </AppShell>
+        </MemoryRouter>
+      </FluentProvider>
+    </ScenarioProvider>
+  );
+}
+
+describe("Scenarios and global scenario context", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    queryReportMock.mockReset();
+    exportReportMock.mockReset();
+    queryReportMock.mockImplementation(async (payload) => {
+      const input = payload as { scenarioId?: string };
+      return {
+        ...datasetFixture,
+        scenarioId: input.scenarioId ?? "baseline"
+      };
+    });
+    exportReportMock.mockResolvedValue({ files: {} });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("updates dashboard and reports queries when the global scenario selector changes", async () => {
+    renderWorkspace("/dashboard");
+
+    await waitFor(() => {
+      expect(queryReportMock).toHaveBeenCalledWith({
+        query: "dashboard.summary",
+        scenarioId: "baseline"
+      });
+    });
+
+    fireEvent.change(screen.getByLabelText("Scenario selector"), {
+      target: { value: "growth" }
+    });
+
+    await waitFor(() => {
+      expect(queryReportMock).toHaveBeenCalledWith({
+        query: "dashboard.summary",
+        scenarioId: "growth"
+      });
+    });
+
+    const callsAfterDashboardUpdate = queryReportMock.mock.calls.length;
+    fireEvent.click(screen.getByRole("link", { name: "Reports" }));
+
+    await waitFor(() => {
+      expect(queryReportMock.mock.calls.length).toBeGreaterThan(callsAfterDashboardUpdate);
+    });
+    expect(queryReportMock.mock.calls.at(-1)?.[0]).toMatchObject({
+      scenarioId: "growth"
+    });
+    expect(screen.getByTestId("reports-scenario-context")).toHaveTextContent("Growth");
+  });
+
+  it("supports clone/promote/lock workflow and applies selected scenario context to dashboard", async () => {
+    renderWorkspace("/scenarios");
+
+    await screen.findByText("Scenarios Workspace");
+    const baselineRow = await screen.findByTestId("scenario-row-baseline");
+
+    fireEvent.click(within(baselineRow).getByRole("button", { name: "Clone" }));
+    const cloneRow = await screen.findByTestId("scenario-row-scenario-baseline-copy");
+
+    fireEvent.click(within(cloneRow).getByRole("button", { name: "Promote" }));
+    expect(within(cloneRow).getByText("REVIEWED")).toBeInTheDocument();
+
+    fireEvent.click(within(cloneRow).getByRole("button", { name: "Lock" }));
+    expect(within(cloneRow).getByText("Locked")).toBeInTheDocument();
+
+    fireEvent.click(within(cloneRow).getByRole("button", { name: "Select" }));
+    expect(screen.getByTestId("selected-scenario-summary")).toHaveTextContent("Baseline Copy");
+
+    const selector = screen.getByLabelText("Scenario selector") as HTMLSelectElement;
+    expect(selector.value).toBe("scenario-baseline-copy");
+
+    fireEvent.click(screen.getByRole("link", { name: "Dashboard" }));
+    await waitFor(() => {
+      expect(queryReportMock).toHaveBeenCalledWith({
+        query: "dashboard.summary",
+        scenarioId: "scenario-baseline-copy"
+      });
+    });
+    expect(screen.getByTestId("dashboard-scenario-context")).toHaveTextContent(
+      "Scenario: Baseline Copy"
+    );
+  });
+});

--- a/apps/renderer/src/features/scenarios/ScenariosPage.tsx
+++ b/apps/renderer/src/features/scenarios/ScenariosPage.tsx
@@ -1,11 +1,168 @@
-import { FeaturePlaceholderPage } from "../common/FeaturePlaceholderPage";
+import { useMemo, useState } from "react";
+import {
+  Button,
+  Card,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Text,
+  Title3
+} from "@fluentui/react-components";
+
+import { PageHeader, StatusChip } from "../../ui/primitives";
+import { useScenarioContext } from "./ScenarioContext";
+import { compareScenarioToBaseline } from "./scenario-model";
+import "./ScenariosPage.css";
+
+function statusToTone(status: "draft" | "reviewed" | "approved"): "info" | "warning" | "success" {
+  if (status === "approved") {
+    return "success";
+  }
+  if (status === "reviewed") {
+    return "warning";
+  }
+  return "info";
+}
+
+function formatCreatedDate(createdAt: string): string {
+  return new Date(createdAt).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric"
+  });
+}
 
 export function ScenariosPage() {
+  const {
+    scenarios,
+    selectedScenario,
+    selectedScenarioId,
+    selectScenario,
+    cloneScenario,
+    promoteScenario,
+    lockScenario
+  } = useScenarioContext();
+  const [comparisonScenarioId, setComparisonScenarioId] = useState<string | null>(null);
+
+  const scenarioNameById = useMemo(
+    () =>
+      Object.fromEntries(scenarios.map((scenario) => [scenario.id, scenario.name])),
+    [scenarios]
+  );
+  const comparisonText = comparisonScenarioId
+    ? compareScenarioToBaseline(
+        { scenarios, selectedScenarioId },
+        comparisonScenarioId
+      )
+    : null;
+
   return (
-    <FeaturePlaceholderPage
-      title="Scenarios"
-      description="Scenario selector, management table, clone/lock/approval actions, and context propagation are planned in U9."
-    />
+    <section className="scenarios-page">
+      <PageHeader
+        title="Scenarios Workspace"
+        subtitle="Clone, promote, lock, and compare scenarios with global context selection."
+      />
+
+      <Card className="scenarios-page__summary">
+        <Title3>Active scenario</Title3>
+        <Text data-testid="selected-scenario-summary">
+          {selectedScenario ? selectedScenario.name : "No active scenario"}
+        </Text>
+      </Card>
+
+      {comparisonText ? (
+        <Card data-testid="scenario-comparison">
+          <Text weight="semibold">Comparison to Baseline</Text>
+          <Text>{comparisonText}</Text>
+        </Card>
+      ) : null}
+
+      <Table aria-label="Scenarios table">
+        <TableHeader>
+          <TableRow>
+            <TableHeaderCell>Name</TableHeaderCell>
+            <TableHeaderCell>Status</TableHeaderCell>
+            <TableHeaderCell>Lock</TableHeaderCell>
+            <TableHeaderCell>Parent</TableHeaderCell>
+            <TableHeaderCell>Created</TableHeaderCell>
+            <TableHeaderCell>Actions</TableHeaderCell>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {scenarios.map((scenario) => {
+            const isSelected = scenario.id === selectedScenarioId;
+            return (
+              <TableRow
+                key={scenario.id}
+                data-testid={`scenario-row-${scenario.id}`}
+                className={
+                  isSelected ? "scenarios-page__row scenarios-page__row--selected" : "scenarios-page__row"
+                }
+              >
+                <TableCell>{scenario.name}</TableCell>
+                <TableCell>
+                  <StatusChip
+                    label={scenario.status.toUpperCase()}
+                    tone={statusToTone(scenario.status)}
+                  />
+                </TableCell>
+                <TableCell>{scenario.locked ? "Locked" : "Open"}</TableCell>
+                <TableCell>
+                  {scenario.parentScenarioId
+                    ? (scenarioNameById[scenario.parentScenarioId] ?? scenario.parentScenarioId)
+                    : "None"}
+                </TableCell>
+                <TableCell>{formatCreatedDate(scenario.createdAt)}</TableCell>
+                <TableCell>
+                  <div className="scenarios-page__actions">
+                    <Button
+                      size="small"
+                      appearance="secondary"
+                      onClick={() => selectScenario(scenario.id)}
+                    >
+                      Select
+                    </Button>
+                    <Button
+                      size="small"
+                      appearance="secondary"
+                      onClick={() => cloneScenario(scenario.id)}
+                    >
+                      Clone
+                    </Button>
+                    <Button
+                      size="small"
+                      appearance="secondary"
+                      disabled={scenario.locked || scenario.status === "approved"}
+                      onClick={() => promoteScenario(scenario.id)}
+                    >
+                      Promote
+                    </Button>
+                    <Button
+                      size="small"
+                      appearance="secondary"
+                      disabled={scenario.locked}
+                      onClick={() => lockScenario(scenario.id)}
+                    >
+                      Lock
+                    </Button>
+                    <Button
+                      size="small"
+                      appearance="secondary"
+                      onClick={() => setComparisonScenarioId(scenario.id)}
+                    >
+                      Compare
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </section>
   );
 }
 

--- a/apps/renderer/src/features/scenarios/scenario-model.test.ts
+++ b/apps/renderer/src/features/scenarios/scenario-model.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_SCENARIO_STATE,
+  getScenarioStorageKey,
+  loadScenarioState,
+  persistScenarioState,
+  scenarioReducer,
+  type ScenarioState
+} from "./scenario-model";
+
+class MemoryStorage {
+  private data = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+}
+
+describe("scenario model", () => {
+  it("supports clone/promote/lock transitions and selection updates", () => {
+    const cloned = scenarioReducer(DEFAULT_SCENARIO_STATE, {
+      type: "clone",
+      sourceScenarioId: "baseline",
+      createdAt: "2026-02-01T00:00:00.000Z"
+    });
+    const clone = cloned.scenarios.find((scenario) => scenario.id === "scenario-baseline-copy");
+    expect(clone).toBeDefined();
+    expect(cloned.selectedScenarioId).toBe("scenario-baseline-copy");
+    expect(clone?.parentScenarioId).toBe("baseline");
+    expect(clone?.status).toBe("draft");
+
+    const promoted = scenarioReducer(cloned, {
+      type: "promote",
+      scenarioId: "scenario-baseline-copy"
+    });
+    expect(
+      promoted.scenarios.find((scenario) => scenario.id === "scenario-baseline-copy")?.status
+    ).toBe("reviewed");
+
+    const locked = scenarioReducer(promoted, {
+      type: "lock",
+      scenarioId: "scenario-baseline-copy"
+    });
+    const lockedScenario = locked.scenarios.find(
+      (scenario) => scenario.id === "scenario-baseline-copy"
+    );
+    expect(lockedScenario?.locked).toBe(true);
+
+    const promotedLocked = scenarioReducer(locked, {
+      type: "promote",
+      scenarioId: "scenario-baseline-copy"
+    });
+    expect(
+      promotedLocked.scenarios.find((scenario) => scenario.id === "scenario-baseline-copy")
+        ?.status
+    ).toBe("reviewed");
+  });
+
+  it("persists and reloads selected scenario, with fallback on invalid persisted state", () => {
+    const storage = new MemoryStorage();
+    const state: ScenarioState = {
+      scenarios: DEFAULT_SCENARIO_STATE.scenarios,
+      selectedScenarioId: "growth"
+    };
+
+    persistScenarioState(state, storage);
+    expect(storage.getItem(getScenarioStorageKey())).toContain("\"selectedScenarioId\":\"growth\"");
+
+    const loaded = loadScenarioState(storage);
+    expect(loaded.selectedScenarioId).toBe("growth");
+
+    storage.setItem(
+      getScenarioStorageKey(),
+      JSON.stringify({
+        scenarios: DEFAULT_SCENARIO_STATE.scenarios,
+        selectedScenarioId: "missing"
+      })
+    );
+    const fallbackLoaded = loadScenarioState(storage);
+    expect(fallbackLoaded.selectedScenarioId).toBe("baseline");
+  });
+});

--- a/apps/renderer/src/features/scenarios/scenario-model.ts
+++ b/apps/renderer/src/features/scenarios/scenario-model.ts
@@ -1,0 +1,258 @@
+export type ScenarioStatus = "draft" | "reviewed" | "approved";
+
+export type ScenarioRecord = {
+  id: string;
+  name: string;
+  status: ScenarioStatus;
+  locked: boolean;
+  parentScenarioId: string | null;
+  createdAt: string;
+};
+
+export type ScenarioState = {
+  selectedScenarioId: string;
+  scenarios: ScenarioRecord[];
+};
+
+export type ScenarioAction =
+  | { type: "select"; scenarioId: string }
+  | { type: "clone"; sourceScenarioId: string; createdAt?: string }
+  | { type: "promote"; scenarioId: string }
+  | { type: "lock"; scenarioId: string }
+  | { type: "replace"; state: ScenarioState };
+
+const SCENARIO_STORAGE_KEY = "budgetit.scenario-state.v1";
+
+export const DEFAULT_SCENARIOS: ScenarioRecord[] = [
+  {
+    id: "baseline",
+    name: "Baseline",
+    status: "approved",
+    locked: false,
+    parentScenarioId: null,
+    createdAt: "2026-01-01T00:00:00.000Z"
+  },
+  {
+    id: "cost-cut",
+    name: "Cost Cut",
+    status: "draft",
+    locked: false,
+    parentScenarioId: "baseline",
+    createdAt: "2026-01-15T00:00:00.000Z"
+  },
+  {
+    id: "growth",
+    name: "Growth",
+    status: "reviewed",
+    locked: false,
+    parentScenarioId: "baseline",
+    createdAt: "2026-01-20T00:00:00.000Z"
+  }
+];
+
+export const DEFAULT_SCENARIO_STATE: ScenarioState = {
+  selectedScenarioId: "baseline",
+  scenarios: DEFAULT_SCENARIOS
+};
+
+export function scenarioReducer(
+  state: ScenarioState,
+  action: ScenarioAction
+): ScenarioState {
+  if (action.type === "replace") {
+    return normalizeScenarioState(action.state);
+  }
+
+  if (action.type === "select") {
+    const exists = state.scenarios.some((scenario) => scenario.id === action.scenarioId);
+    if (!exists) {
+      return state;
+    }
+    return {
+      ...state,
+      selectedScenarioId: action.scenarioId
+    };
+  }
+
+  if (action.type === "clone") {
+    const source = state.scenarios.find(
+      (scenario) => scenario.id === action.sourceScenarioId
+    );
+    if (!source) {
+      return state;
+    }
+
+    const cloneNameBase = `${source.name} Copy`;
+    const cloneName = nextCloneName(cloneNameBase, state.scenarios);
+    const cloneId = nextScenarioId(cloneName, state.scenarios);
+    const createdAt = action.createdAt ?? new Date().toISOString();
+
+    const clone: ScenarioRecord = {
+      id: cloneId,
+      name: cloneName,
+      status: "draft",
+      locked: false,
+      parentScenarioId: source.id,
+      createdAt
+    };
+
+    return {
+      scenarios: [...state.scenarios, clone],
+      selectedScenarioId: clone.id
+    };
+  }
+
+  if (action.type === "promote") {
+    return {
+      ...state,
+      scenarios: state.scenarios.map((scenario) => {
+        if (scenario.id !== action.scenarioId || scenario.locked) {
+          return scenario;
+        }
+        if (scenario.status === "draft") {
+          return { ...scenario, status: "reviewed" };
+        }
+        if (scenario.status === "reviewed") {
+          return { ...scenario, status: "approved" };
+        }
+        return scenario;
+      })
+    };
+  }
+
+  return {
+    ...state,
+    scenarios: state.scenarios.map((scenario) =>
+      scenario.id === action.scenarioId ? { ...scenario, locked: true } : scenario
+    )
+  };
+}
+
+export function normalizeScenarioState(input: ScenarioState): ScenarioState {
+  const scenarios = input.scenarios.filter(isScenarioRecord);
+  if (scenarios.length === 0) {
+    return DEFAULT_SCENARIO_STATE;
+  }
+  const selectedExists = scenarios.some(
+    (scenario) => scenario.id === input.selectedScenarioId
+  );
+  return {
+    scenarios,
+    selectedScenarioId: selectedExists ? input.selectedScenarioId : scenarios[0].id
+  };
+}
+
+export function loadScenarioState(
+  storage: Pick<Storage, "getItem"> | null | undefined = getStorage()
+): ScenarioState {
+  if (!storage) {
+    return DEFAULT_SCENARIO_STATE;
+  }
+  const raw = storage.getItem(SCENARIO_STORAGE_KEY);
+  if (!raw) {
+    return DEFAULT_SCENARIO_STATE;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as ScenarioState;
+    return normalizeScenarioState(parsed);
+  } catch {
+    return DEFAULT_SCENARIO_STATE;
+  }
+}
+
+export function persistScenarioState(
+  state: ScenarioState,
+  storage: Pick<Storage, "setItem"> | null | undefined = getStorage()
+): void {
+  if (!storage) {
+    return;
+  }
+  storage.setItem(SCENARIO_STORAGE_KEY, JSON.stringify(state));
+}
+
+export function getScenarioStorageKey(): string {
+  return SCENARIO_STORAGE_KEY;
+}
+
+export function compareScenarioToBaseline(
+  state: ScenarioState,
+  scenarioId: string
+): string {
+  const baseline = state.scenarios.find((scenario) => scenario.id === "baseline");
+  const target = state.scenarios.find((scenario) => scenario.id === scenarioId);
+  if (!baseline || !target) {
+    return "Comparison unavailable.";
+  }
+
+  const statusText =
+    baseline.status === target.status
+      ? "status matches baseline"
+      : `status ${target.status} vs baseline ${baseline.status}`;
+  const lockText =
+    baseline.locked === target.locked
+      ? "lock state matches baseline"
+      : target.locked
+        ? "target is locked while baseline is open"
+        : "target is open while baseline is locked";
+
+  return `${target.name}: ${statusText}; ${lockText}.`;
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null;
+  }
+  return window.localStorage;
+}
+
+function nextCloneName(baseName: string, scenarios: ScenarioRecord[]): string {
+  const usedNames = new Set(scenarios.map((scenario) => scenario.name));
+  if (!usedNames.has(baseName)) {
+    return baseName;
+  }
+  let index = 2;
+  while (usedNames.has(`${baseName} ${index}`)) {
+    index += 1;
+  }
+  return `${baseName} ${index}`;
+}
+
+function nextScenarioId(name: string, scenarios: ScenarioRecord[]): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  const usedIds = new Set(scenarios.map((scenario) => scenario.id));
+  const baseId = `scenario-${slug}`;
+  if (!usedIds.has(baseId)) {
+    return baseId;
+  }
+  let index = 2;
+  while (usedIds.has(`${baseId}-${index}`)) {
+    index += 1;
+  }
+  return `${baseId}-${index}`;
+}
+
+function isScenarioStatus(value: string): value is ScenarioStatus {
+  return value === "draft" || value === "reviewed" || value === "approved";
+}
+
+function isScenarioRecord(value: unknown): value is ScenarioRecord {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const input = value as Record<string, unknown>;
+  return (
+    typeof input.id === "string" &&
+    typeof input.name === "string" &&
+    typeof input.locked === "boolean" &&
+    (input.parentScenarioId === null || typeof input.parentScenarioId === "string") &&
+    typeof input.createdAt === "string" &&
+    typeof input.status === "string" &&
+    isScenarioStatus(input.status)
+  );
+}

--- a/apps/renderer/src/features/services/ServiceContractWorkspaces.test.tsx
+++ b/apps/renderer/src/features/services/ServiceContractWorkspaces.test.tsx
@@ -92,10 +92,6 @@ describe("service and contract workspaces", () => {
     await waitFor(() => {
       expect(screen.getByTestId("page-title")).toHaveTextContent("Reports");
     });
-    expect(
-      screen.getByText(
-        "Report gallery and configurable reporting workspace with export orchestration are planned in U11."
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("reports-scenario-context")).toHaveTextContent("Baseline");
   });
 });

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -5,18 +5,21 @@ import { BrowserRouter } from "react-router-dom";
 
 import { AppShell } from "./app/AppShell";
 import { AppRoutes } from "./app/routes";
+import { ScenarioProvider } from "./features/scenarios/ScenarioContext";
 import "./App.css";
 import { budgetItLightTheme } from "./ui/theme";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <FluentProvider theme={budgetItLightTheme}>
-      <BrowserRouter>
-        <AppShell>
-          <AppRoutes />
-        </AppShell>
-      </BrowserRouter>
-    </FluentProvider>
+    <ScenarioProvider>
+      <FluentProvider theme={budgetItLightTheme}>
+        <BrowserRouter>
+          <AppShell>
+            <AppRoutes />
+          </AppShell>
+        </BrowserRouter>
+      </FluentProvider>
+    </ScenarioProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- add persistent scenario state model with reducer + localStorage persistence for selected scenario and scenario records
- introduce ScenarioProvider and wire global top-bar scenario selector to shared context
- implement Scenarios workspace with table fields, clone/promote/lock actions, compare-to-baseline output, and active scenario summary
- propagate scenario context into dashboard and reports queries/exports, with scenario indicators in page headers and metadata panels
- replace reports placeholder with a scenario-aware reporting workspace shell

## Testing
- npm run lint --workspace @budgetit/renderer
- npm run typecheck --workspace @budgetit/renderer
- npm run test --workspace @budgetit/renderer
- npm run build --workspace @budgetit/renderer

Closes #65