### PR TITLE
[U10] Import wizard stepper with preview, error review, and unmatched queue

### DIFF
--- a/apps/renderer/src/features/import/ImportPage.css
+++ b/apps/renderer/src/features/import/ImportPage.css
@@ -1,0 +1,53 @@
+.import-page {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem 1.25rem;
+}
+
+.import-stepper {
+  margin: 0;
+  padding-left: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.import-stepper__item {
+  opacity: 0.7;
+}
+
+.import-stepper__item--active {
+  font-weight: 700;
+  opacity: 1;
+}
+
+.import-flags {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.import-summary-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.import-error-list,
+.import-suggestion-list,
+.import-unmatched-list {
+  margin: 0.35rem 0 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.import-commit-summary {
+  display: grid;
+  gap: 0.2rem;
+  margin-top: 0.5rem;
+}
+
+.import-nav {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/apps/renderer/src/features/import/ImportPage.test.tsx
+++ b/apps/renderer/src/features/import/ImportPage.test.tsx
@@ -1,0 +1,160 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { commitImport, previewImport } from "../../lib/ipcClient";
+import { budgetItLightTheme } from "../../ui/theme";
+import { ImportPage } from "./ImportPage";
+
+vi.mock("../../lib/ipcClient", () => ({
+  previewImport: vi.fn(),
+  commitImport: vi.fn()
+}));
+
+const previewImportMock = vi.mocked(previewImport);
+const commitImportMock = vi.mocked(commitImport);
+
+function renderImportPage() {
+  return render(
+    <FluentProvider theme={budgetItLightTheme}>
+      <MemoryRouter>
+        <ImportPage />
+      </MemoryRouter>
+    </FluentProvider>
+  );
+}
+
+describe("ImportPage", () => {
+  beforeEach(() => {
+    previewImportMock.mockReset();
+    commitImportMock.mockReset();
+    previewImportMock.mockResolvedValue({
+      totalRows: 6,
+      acceptedCount: 4,
+      rejectedCount: 1,
+      duplicateCount: 1,
+      templateApplied: "actuals-template",
+      templateSaved: "actuals-template",
+      errors: [
+        {
+          rowNumber: 3,
+          code: "validation",
+          field: "amount",
+          message: "Amount is required"
+        },
+        {
+          rowNumber: 5,
+          code: "duplicate",
+          field: "row",
+          message: "Duplicate row fingerprint"
+        }
+      ]
+    });
+    commitImportMock.mockResolvedValue({
+      totalRows: 6,
+      acceptedCount: 4,
+      rejectedCount: 1,
+      duplicateCount: 1,
+      insertedCount: 4,
+      skippedDuplicateCount: 1,
+      matchedCount: 3,
+      unmatchedCount: 1,
+      matchRate: 0.75,
+      unmatchedForReview: [
+        {
+          id: "txn-1",
+          transactionDate: "2026-02-10",
+          amountMinor: 84000,
+          description: "Unmapped purchase"
+        }
+      ],
+      errors: []
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("sends preview and commit IPC payloads with selected template and options", async () => {
+    renderImportPage();
+
+    fireEvent.change(screen.getByLabelText("Import mode"), {
+      target: { value: "actuals" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    fireEvent.change(screen.getByLabelText("Import file path"), {
+      target: { value: "C:\\imports\\actuals.xlsx" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    fireEvent.change(screen.getByLabelText("Mapping template"), {
+      target: { value: "actuals-template" }
+    });
+    fireEvent.click(screen.getByLabelText("Use saved template"));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Run preview" }));
+    await waitFor(() => {
+      expect(previewImportMock).toHaveBeenCalledWith({
+        mode: "actuals",
+        filePath: "C:\\imports\\actuals.xlsx",
+        templateName: "actuals-template",
+        useSavedTemplate: false,
+        saveTemplate: true
+      });
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Commit import" }));
+
+    await waitFor(() => {
+      expect(commitImportMock).toHaveBeenCalledWith({
+        mode: "actuals",
+        filePath: "C:\\imports\\actuals.xlsx",
+        templateName: "actuals-template",
+        useSavedTemplate: false,
+        saveTemplate: true
+      });
+    });
+  });
+
+  it("runs full wizard and displays accepted/rejected/duplicate and unmatched queue counts", async () => {
+    renderImportPage();
+
+    fireEvent.change(screen.getByLabelText("Import mode"), {
+      target: { value: "actuals" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.change(screen.getByLabelText("Import file path"), {
+      target: { value: "C:\\imports\\sample.xlsx" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Run preview" }));
+    expect(await screen.findByText("Accepted: 4")).toBeInTheDocument();
+    expect(screen.getByText("Rejected: 1")).toBeInTheDocument();
+    expect(screen.getByText("Duplicates: 1")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Error filter"), {
+      target: { value: "duplicate" }
+    });
+    expect(screen.getByText(/Duplicate row fingerprint/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    fireEvent.click(screen.getByRole("button", { name: "Commit import" }));
+    const commitSummary = await screen.findByTestId("import-commit-summary");
+    expect(commitSummary).toHaveTextContent("Accepted: 4");
+    expect(commitSummary).toHaveTextContent("Rejected: 1");
+    expect(commitSummary).toHaveTextContent("Duplicates: 1");
+    expect(commitSummary).toHaveTextContent("Matched: 3");
+    expect(commitSummary).toHaveTextContent("Unmatched: 1");
+    expect(screen.getByText(/2026-02-10/i)).toBeInTheDocument();
+  });
+});

--- a/apps/renderer/src/features/import/ImportPage.tsx
+++ b/apps/renderer/src/features/import/ImportPage.tsx
@@ -1,11 +1,421 @@
-import { FeaturePlaceholderPage } from "../common/FeaturePlaceholderPage";
+import { useMemo, useState } from "react";
+import {
+  Badge,
+  Button,
+  Card,
+  Checkbox,
+  Input,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Text,
+  Title3
+} from "@fluentui/react-components";
+
+import { commitImport, previewImport } from "../../lib/ipcClient";
+import { InlineError, PageHeader } from "../../ui/primitives";
+import {
+  buildImportPayload,
+  canAdvanceStep,
+  createInitialImportWizardDraft,
+  filterImportErrors,
+  IMPORT_WIZARD_STEPS,
+  nextStep,
+  previousStep,
+  type ImportErrorFilter,
+  type ImportWizardStep
+} from "./import-wizard-model";
+import "./ImportPage.css";
+
+type PreviewRow = {
+  rowNumber: number;
+  name: string;
+  amount: string;
+  status: "accepted" | "rejected" | "duplicate";
+};
+
+type TagSuggestion = {
+  id: string;
+  label: string;
+  selected: boolean;
+};
+
+const PREVIEW_ROWS_BY_MODE: Record<"expenses" | "actuals", PreviewRow[]> = {
+  expenses: [
+    { rowNumber: 1, name: "Cloud Compute", amount: "$2,400.00", status: "accepted" },
+    { rowNumber: 2, name: "Endpoint Security", amount: "$840.00", status: "duplicate" },
+    { rowNumber: 3, name: "Analytics Suite", amount: "$1,250.00", status: "rejected" }
+  ],
+  actuals: [
+    { rowNumber: 1, name: "Invoice 8820", amount: "$2,400.00", status: "accepted" },
+    { rowNumber: 2, name: "Invoice 8821", amount: "$840.00", status: "duplicate" },
+    { rowNumber: 3, name: "Invoice 8822", amount: "$770.00", status: "rejected" }
+  ]
+};
+
+const DEFAULT_TAG_SUGGESTIONS: TagSuggestion[] = [
+  { id: "suggestion-msft-security", label: "Vendor contains Microsoft -> Cost Center: Security", selected: true },
+  { id: "suggestion-aws-engineering", label: "Vendor contains AWS -> Cost Center: Engineering", selected: true },
+  { id: "suggestion-prod-env", label: "Description contains production -> Environment: Production", selected: false }
+];
+
+function stepLabel(step: ImportWizardStep): string {
+  if (step === "mode") {
+    return "Mode";
+  }
+  if (step === "file") {
+    return "File";
+  }
+  if (step === "mapping") {
+    return "Mapping";
+  }
+  if (step === "preview") {
+    return "Preview";
+  }
+  return "Commit";
+}
 
 export function ImportPage() {
+  const [draft, setDraft] = useState(() => createInitialImportWizardDraft());
+  const [currentStep, setCurrentStep] = useState<ImportWizardStep>("mode");
+  const [errorFilter, setErrorFilter] = useState<ImportErrorFilter>("all");
+  const [busy, setBusy] = useState(false);
+  const [pageError, setPageError] = useState<string | null>(null);
+  const [pageMessage, setPageMessage] = useState<string | null>(null);
+  const [tagSuggestions, setTagSuggestions] = useState<TagSuggestion[]>(
+    DEFAULT_TAG_SUGGESTIONS
+  );
+
+  const filteredErrors = useMemo(() => {
+    if (!draft.previewResult) {
+      return [];
+    }
+    return filterImportErrors(draft.previewResult.errors, errorFilter);
+  }, [draft.previewResult, errorFilter]);
+  const previewRows = PREVIEW_ROWS_BY_MODE[draft.mode];
+  const selectedSuggestionCount = tagSuggestions.filter((entry) => entry.selected).length;
+
+  function onNext(): void {
+    if (!canAdvanceStep(currentStep, draft)) {
+      if (currentStep === "file") {
+        setPageError("Choose a file path before moving to mapping.");
+      } else if (currentStep === "preview") {
+        setPageError("Run preview before moving to commit.");
+      } else {
+        setPageError("Complete required fields before moving to next step.");
+      }
+      return;
+    }
+    setPageError(null);
+    setCurrentStep((current) => nextStep(current, draft));
+  }
+
+  function onBack(): void {
+    setPageError(null);
+    setCurrentStep((current) => previousStep(current));
+  }
+
+  async function onRunPreview(): Promise<void> {
+    setBusy(true);
+    setPageError(null);
+    setPageMessage(null);
+    try {
+      const result = await previewImport(buildImportPayload(draft));
+      setDraft((current) => ({ ...current, previewResult: result, commitResult: null }));
+      setPageMessage(
+        `Preview loaded: ${result.acceptedCount} accepted, ${result.rejectedCount} rejected, ${result.duplicateCount} duplicates.`
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      setPageError(`Preview failed: ${detail}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onRunCommit(): Promise<void> {
+    setBusy(true);
+    setPageError(null);
+    setPageMessage(null);
+    try {
+      const result = await commitImport(buildImportPayload(draft));
+      setDraft((current) => ({ ...current, commitResult: result }));
+      setPageMessage(
+        `Commit completed: ${result.insertedCount} inserted, ${result.rejectedCount} rejected, ${result.duplicateCount} duplicates.`
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      setPageError(`Commit failed: ${detail}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function toggleSuggestion(id: string, checked: boolean): void {
+    setTagSuggestions((current) =>
+      current.map((entry) => (entry.id === id ? { ...entry, selected: checked } : entry))
+    );
+  }
+
   return (
-    <FeaturePlaceholderPage
-      title="Import"
-      description="Stepper-driven import workflow with preview, validation, and unmatched queue handling is planned in U10."
-    />
+    <section className="import-page">
+      <PageHeader
+        title="Import Wizard"
+        subtitle="Guided stepper for mode, mapping, preview, and commit with deterministic dedupe outcomes."
+      />
+
+      <Card>
+        <ol className="import-stepper">
+          {IMPORT_WIZARD_STEPS.map((step) => (
+            <li
+              key={step}
+              className={
+                step === currentStep
+                  ? "import-stepper__item import-stepper__item--active"
+                  : "import-stepper__item"
+              }
+              data-testid={`import-step-${step}`}
+            >
+              {stepLabel(step)}
+            </li>
+          ))}
+        </ol>
+      </Card>
+
+      {currentStep === "mode" ? (
+        <Card>
+          <Title3>Step 1: Select import mode</Title3>
+          <Select
+            aria-label="Import mode"
+            value={draft.mode}
+            onChange={(event) =>
+              setDraft((current) => ({
+                ...current,
+                mode: event.target.value as "expenses" | "actuals",
+                previewResult: null,
+                commitResult: null
+              }))
+            }
+          >
+            <option value="expenses">Expenses</option>
+            <option value="actuals">Actuals</option>
+          </Select>
+        </Card>
+      ) : null}
+
+      {currentStep === "file" ? (
+        <Card>
+          <Title3>Step 2: Select file</Title3>
+          <Input
+            aria-label="Import file path"
+            value={draft.filePath}
+            onChange={(_event, data) =>
+              setDraft((current) => ({ ...current, filePath: data.value }))
+            }
+            placeholder="C:\\imports\\budget.xlsx"
+          />
+        </Card>
+      ) : null}
+
+      {currentStep === "mapping" ? (
+        <Card>
+          <Title3>Step 3: Mapping template</Title3>
+          <Input
+            aria-label="Mapping template"
+            value={draft.templateName}
+            onChange={(_event, data) =>
+              setDraft((current) => ({ ...current, templateName: data.value }))
+            }
+            placeholder="default-expense-import"
+          />
+          <div className="import-flags">
+            <Checkbox
+              label="Use saved template"
+              checked={draft.useSavedTemplate}
+              onChange={(_event, data) =>
+                setDraft((current) => ({
+                  ...current,
+                  useSavedTemplate: data.checked === true
+                }))
+              }
+            />
+            <Checkbox
+              label="Save template"
+              checked={draft.saveTemplate}
+              onChange={(_event, data) =>
+                setDraft((current) => ({
+                  ...current,
+                  saveTemplate: data.checked === true
+                }))
+              }
+            />
+          </div>
+        </Card>
+      ) : null}
+
+      {currentStep === "preview" ? (
+        <Card>
+          <Title3>Step 4: Preview</Title3>
+          <Button appearance="primary" disabled={busy} onClick={() => void onRunPreview()}>
+            {busy ? "Previewing..." : "Run preview"}
+          </Button>
+
+          {draft.previewResult ? (
+            <>
+              <div className="import-summary-grid">
+                <Badge appearance="filled" color="success">
+                  {`Accepted: ${draft.previewResult.acceptedCount}`}
+                </Badge>
+                <Badge appearance="filled" color="danger">
+                  {`Rejected: ${draft.previewResult.rejectedCount}`}
+                </Badge>
+                <Badge appearance="filled" color="warning">
+                  {`Duplicates: ${draft.previewResult.duplicateCount}`}
+                </Badge>
+              </div>
+              <Text>{`Dedupe policy: deterministic fingerprint keeps earliest row and skips subsequent duplicates.`}</Text>
+
+              <Table aria-label="Import preview rows">
+                <TableHeader>
+                  <TableRow>
+                    <TableHeaderCell>Row</TableHeaderCell>
+                    <TableHeaderCell>Name</TableHeaderCell>
+                    <TableHeaderCell>Amount</TableHeaderCell>
+                    <TableHeaderCell>Status</TableHeaderCell>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {previewRows.map((row) => (
+                    <TableRow key={`${row.rowNumber}-${row.name}`}>
+                      <TableCell>{row.rowNumber}</TableCell>
+                      <TableCell>{row.name}</TableCell>
+                      <TableCell>{row.amount}</TableCell>
+                      <TableCell>{row.status}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+
+              <Card>
+                <Title3>Error review</Title3>
+                <Select
+                  aria-label="Error filter"
+                  value={errorFilter}
+                  onChange={(event) =>
+                    setErrorFilter(event.target.value as ImportErrorFilter)
+                  }
+                >
+                  <option value="all">All errors</option>
+                  <option value="validation">Validation</option>
+                  <option value="duplicate">Duplicate</option>
+                </Select>
+                {filteredErrors.length === 0 ? (
+                  <Text>No errors match selected filter.</Text>
+                ) : (
+                  <ul className="import-error-list">
+                    {filteredErrors.map((entry) => (
+                      <li key={`${entry.rowNumber}-${entry.code}-${entry.field}`}>
+                        <Text>{`Row ${entry.rowNumber} (${entry.code}) ${entry.field}: ${entry.message}`}</Text>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </Card>
+
+              <Card>
+                <Title3>Optional tagging suggestions</Title3>
+                <Text>{`${selectedSuggestionCount} suggestion(s) selected.`}</Text>
+                <ul className="import-suggestion-list">
+                  {tagSuggestions.map((entry) => (
+                    <li key={entry.id}>
+                      <Checkbox
+                        label={entry.label}
+                        checked={entry.selected}
+                        onChange={(_event, data) =>
+                          toggleSuggestion(entry.id, data.checked === true)
+                        }
+                      />
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            </>
+          ) : null}
+        </Card>
+      ) : null}
+
+      {currentStep === "commit" ? (
+        <Card>
+          <Title3>Step 5: Commit</Title3>
+          <Button
+            appearance="primary"
+            disabled={busy || draft.previewResult === null}
+            onClick={() => void onRunCommit()}
+          >
+            {busy ? "Committing..." : "Commit import"}
+          </Button>
+
+          {draft.commitResult ? (
+            <div className="import-commit-summary" data-testid="import-commit-summary">
+              <Text>{`Accepted: ${draft.commitResult.acceptedCount}`}</Text>
+              <Text>{`Rejected: ${draft.commitResult.rejectedCount}`}</Text>
+              <Text>{`Duplicates: ${draft.commitResult.duplicateCount}`}</Text>
+              <Text>{`Inserted: ${draft.commitResult.insertedCount}`}</Text>
+              {draft.mode === "actuals" ? (
+                <>
+                  <Text>{`Matched: ${draft.commitResult.matchedCount ?? 0}`}</Text>
+                  <Text>{`Unmatched: ${draft.commitResult.unmatchedCount ?? 0}`}</Text>
+                  <Text>{`Match rate: ${((draft.commitResult.matchRate ?? 0) * 100).toFixed(1)}%`}</Text>
+                  <Card>
+                    <Title3>Unmatched actuals queue</Title3>
+                    {draft.commitResult.unmatchedForReview?.length ? (
+                      <ul className="import-unmatched-list">
+                        {draft.commitResult.unmatchedForReview.map((entry) => (
+                          <li key={entry.id}>
+                            <Text>{`${entry.transactionDate} • $${(entry.amountMinor / 100).toFixed(2)} • ${
+                              entry.description ?? "No description"
+                            }`}</Text>
+                            <Button size="small" appearance="secondary">
+                              Queue follow-up
+                            </Button>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <Text>No unmatched rows.</Text>
+                    )}
+                  </Card>
+                </>
+              ) : null}
+            </div>
+          ) : null}
+        </Card>
+      ) : null}
+
+      {pageError ? <InlineError message={pageError} /> : null}
+      {pageMessage ? <Text>{pageMessage}</Text> : null}
+
+      <div className="import-nav">
+        <Button
+          appearance="secondary"
+          disabled={currentStep === "mode" || busy}
+          onClick={onBack}
+        >
+          Back
+        </Button>
+        <Button
+          appearance="primary"
+          disabled={currentStep === "commit" || busy}
+          onClick={onNext}
+        >
+          Next
+        </Button>
+      </div>
+    </section>
   );
 }
 

--- a/apps/renderer/src/features/import/import-wizard-model.test.ts
+++ b/apps/renderer/src/features/import/import-wizard-model.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildImportPayload,
+  canAdvanceStep,
+  createInitialImportWizardDraft,
+  nextStep,
+  previousStep
+} from "./import-wizard-model";
+
+describe("import wizard model", () => {
+  it("enforces guard conditions before advancing each step", () => {
+    const initial = createInitialImportWizardDraft();
+    expect(canAdvanceStep("mode", initial)).toBe(true);
+    expect(canAdvanceStep("file", initial)).toBe(false);
+    expect(canAdvanceStep("mapping", initial)).toBe(true);
+    expect(canAdvanceStep("preview", initial)).toBe(false);
+    expect(nextStep("file", initial)).toBe("file");
+    expect(previousStep("mode")).toBe("mode");
+  });
+
+  it("supports deterministic step progression and payload generation", () => {
+    const draft = createInitialImportWizardDraft();
+    draft.mode = "actuals";
+    draft.filePath = "C:\\imports\\actuals.xlsx";
+    draft.templateName = "actuals-template";
+    draft.previewResult = {
+      totalRows: 5,
+      acceptedCount: 4,
+      rejectedCount: 1,
+      duplicateCount: 1,
+      templateApplied: "actuals-template",
+      templateSaved: "actuals-template",
+      errors: []
+    };
+
+    expect(nextStep("mode", draft)).toBe("file");
+    expect(nextStep("file", draft)).toBe("mapping");
+    expect(nextStep("mapping", draft)).toBe("preview");
+    expect(nextStep("preview", draft)).toBe("commit");
+
+    expect(buildImportPayload(draft)).toEqual({
+      mode: "actuals",
+      filePath: "C:\\imports\\actuals.xlsx",
+      templateName: "actuals-template",
+      useSavedTemplate: true,
+      saveTemplate: true
+    });
+  });
+});

--- a/apps/renderer/src/features/import/import-wizard-model.ts
+++ b/apps/renderer/src/features/import/import-wizard-model.ts
@@ -1,0 +1,121 @@
+import type {
+  ImportCommitResult,
+  ImportPreviewResult,
+  ImportRowError
+} from "../../lib/ipcClient";
+
+export type ImportWizardStep = "mode" | "file" | "mapping" | "preview" | "commit";
+export type ImportErrorFilter = "all" | "validation" | "duplicate";
+
+export const IMPORT_WIZARD_STEPS: ImportWizardStep[] = [
+  "mode",
+  "file",
+  "mapping",
+  "preview",
+  "commit"
+];
+
+export type ImportWizardDraft = {
+  mode: "expenses" | "actuals";
+  filePath: string;
+  templateName: string;
+  useSavedTemplate: boolean;
+  saveTemplate: boolean;
+  previewResult: ImportPreviewResult | null;
+  commitResult: ImportCommitResult | null;
+};
+
+export function createInitialImportWizardDraft(): ImportWizardDraft {
+  return {
+    mode: "expenses",
+    filePath: "",
+    templateName: "default-expense-import",
+    useSavedTemplate: true,
+    saveTemplate: true,
+    previewResult: null,
+    commitResult: null
+  };
+}
+
+export function canAdvanceStep(
+  step: ImportWizardStep,
+  draft: ImportWizardDraft
+): boolean {
+  if (step === "mode") {
+    return true;
+  }
+  if (step === "file") {
+    return draft.filePath.trim().length > 0;
+  }
+  if (step === "mapping") {
+    return draft.templateName.trim().length > 0;
+  }
+  if (step === "preview") {
+    return draft.previewResult !== null;
+  }
+  return false;
+}
+
+export function nextStep(
+  step: ImportWizardStep,
+  draft: ImportWizardDraft
+): ImportWizardStep {
+  if (!canAdvanceStep(step, draft)) {
+    return step;
+  }
+  if (step === "mode") {
+    return "file";
+  }
+  if (step === "file") {
+    return "mapping";
+  }
+  if (step === "mapping") {
+    return "preview";
+  }
+  if (step === "preview") {
+    return "commit";
+  }
+  return "commit";
+}
+
+export function previousStep(step: ImportWizardStep): ImportWizardStep {
+  if (step === "file") {
+    return "mode";
+  }
+  if (step === "mapping") {
+    return "file";
+  }
+  if (step === "preview") {
+    return "mapping";
+  }
+  if (step === "commit") {
+    return "preview";
+  }
+  return "mode";
+}
+
+export function buildImportPayload(draft: ImportWizardDraft): {
+  mode: "expenses" | "actuals";
+  filePath: string;
+  templateName: string;
+  useSavedTemplate: boolean;
+  saveTemplate: boolean;
+} {
+  return {
+    mode: draft.mode,
+    filePath: draft.filePath.trim(),
+    templateName: draft.templateName.trim(),
+    useSavedTemplate: draft.useSavedTemplate,
+    saveTemplate: draft.saveTemplate
+  };
+}
+
+export function filterImportErrors(
+  errors: ImportRowError[],
+  filter: ImportErrorFilter
+): ImportRowError[] {
+  if (filter === "all") {
+    return errors;
+  }
+  return errors.filter((entry) => entry.code === filter);
+}


### PR DESCRIPTION
## Summary
- replace import placeholder with a five-step wizard: Mode -> File -> Mapping -> Preview -> Commit
- add import wizard state model with guard-based step transitions and payload builder helpers
- implement preview error review with filter controls and deterministic dedupe summary
- add optional tagging suggestions in preview and unmatched-actuals queue actions in commit step
- add renderer tests for wizard model transitions, IPC payload integration, and full flow count verification

## Testing
- npm run lint --workspace @budgetit/renderer
- npm run typecheck --workspace @budgetit/renderer
- npm run test --workspace @budgetit/renderer
- npm run build --workspace @budgetit/renderer

Closes #66