### PR TITLE
[U11] Reports workspace and gallery with filters, visual blocks, and export jobs

### DIFF
--- a/apps/renderer/src/features/reports/ReportsPage.css
+++ b/apps/renderer/src/features/reports/ReportsPage.css
@@ -4,15 +4,84 @@
   padding: 1rem 1.25rem;
 }
 
-.reports-page__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
 .reports-page__export-list {
   margin: 0.3rem 0 0;
   padding-left: 1rem;
   display: grid;
   gap: 0.15rem;
+}
+
+.reports-gallery {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+}
+
+.reports-gallery__card {
+  border: 1px solid #d1d9e0;
+  border-radius: 8px;
+  padding: 0.6rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.reports-gallery__card--active {
+  border-color: #0b5fff;
+  background: #eef5ff;
+}
+
+.reports-filters {
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+.reports-visualizations {
+  margin-top: 0.55rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.reports-export-controls,
+.reports-save-preset {
+  display: grid;
+  gap: 0.45rem;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+}
+
+.reports-blocks {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.reports-chart {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.reports-chart__row {
+  display: grid;
+  grid-template-columns: minmax(5rem, auto) 1fr auto;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.reports-chart__bar-track {
+  background: #e9edf2;
+  border-radius: 999px;
+  min-height: 0.55rem;
+}
+
+.reports-chart__bar {
+  height: 0.55rem;
+  border-radius: 999px;
+  background: #0b5fff;
+}
+
+.reports-narrative {
+  margin: 0.2rem 0 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.25rem;
 }

--- a/apps/renderer/src/features/reports/ReportsPage.test.tsx
+++ b/apps/renderer/src/features/reports/ReportsPage.test.tsx
@@ -1,0 +1,170 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DashboardDataset } from "../../reporting";
+import { exportReport, queryReport } from "../../lib/ipcClient";
+import { budgetItLightTheme } from "../../ui/theme";
+import { ReportsPage } from "./ReportsPage";
+
+vi.mock("../../lib/ipcClient", () => ({
+  queryReport: vi.fn(),
+  exportReport: vi.fn()
+}));
+
+const queryReportMock = vi.mocked(queryReport);
+const exportReportMock = vi.mocked(exportReport);
+
+const datasetFixture: DashboardDataset = {
+  scenarioId: "baseline",
+  staleForecast: false,
+  spendTrend: [
+    { month: "2026-01", forecastMinor: 12000, actualMinor: 11000 },
+    { month: "2026-02", forecastMinor: 13500, actualMinor: 14000 }
+  ],
+  variance: [
+    {
+      month: "2026-01",
+      forecastMinor: 12000,
+      actualMinor: 11000,
+      varianceMinor: -1000,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    }
+  ],
+  renewals: [{ month: "2026-06", count: 2 }],
+  growth: [{ month: "2026-01", forecastMinor: 12000, growthPct: null }],
+  taggingCompleteness: {
+    totalExpenseLines: 10,
+    taggedExpenseLines: 8,
+    completenessRatio: 0.8
+  },
+  replacementStatus: {
+    totalPlans: 3,
+    replacementRequiredOpen: 1,
+    byStatus: [{ status: "draft", count: 3 }]
+  },
+  narrativeBlocks: [{ id: "summary", title: "Summary", body: "Report narrative." }]
+};
+
+function renderReportsPage() {
+  return render(
+    <FluentProvider theme={budgetItLightTheme}>
+      <MemoryRouter>
+        <ReportsPage />
+      </MemoryRouter>
+    </FluentProvider>
+  );
+}
+
+describe("ReportsPage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    queryReportMock.mockReset();
+    exportReportMock.mockReset();
+    queryReportMock.mockResolvedValue(datasetFixture);
+    exportReportMock.mockImplementation(async (payload) => {
+      const input = payload as { formats: Array<"html" | "pdf" | "excel" | "csv" | "png"> };
+      const format = input.formats[0];
+      return {
+        files: {
+          [format]: `C:\\exports\\report.${format}`
+        }
+      };
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("refreshes dataset when filters change and preserves visualization toggle state", async () => {
+    renderReportsPage();
+
+    await waitFor(() => {
+      expect(queryReportMock).toHaveBeenCalledWith({
+        query: "dashboard.summary",
+        scenarioId: "baseline",
+        filters: {
+          dateFrom: "2026-01-01",
+          dateTo: "2026-12-31",
+          tag: "all"
+        }
+      });
+    });
+
+    const chartToggle = screen.getByLabelText("Show chart block") as HTMLInputElement;
+    fireEvent.click(chartToggle);
+    expect(chartToggle.checked).toBe(false);
+
+    fireEvent.change(screen.getByLabelText("Filter start date"), {
+      target: { value: "2026-03-01" }
+    });
+    fireEvent.change(screen.getByLabelText("Filter tag"), {
+      target: { value: "security" }
+    });
+
+    await waitFor(() => {
+      expect(queryReportMock).toHaveBeenCalledWith({
+        query: "dashboard.summary",
+        scenarioId: "baseline",
+        filters: {
+          dateFrom: "2026-03-01",
+          dateTo: "2026-12-31",
+          tag: "security"
+        }
+      });
+    });
+    expect((screen.getByLabelText("Show chart block") as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("opens gallery report, updates filters, exports two formats, and shows job results", async () => {
+    renderReportsPage();
+    await screen.findByText("Report Gallery");
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Spend by Vendor" }));
+    fireEvent.change(screen.getByLabelText("Filter tag"), {
+      target: { value: "finance" }
+    });
+    fireEvent.change(screen.getByLabelText("Export destination"), {
+      target: { value: "C:\\exports\\reports" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Confirm destination" }));
+
+    fireEvent.change(screen.getByLabelText("Export format"), {
+      target: { value: "csv" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Queue export" }));
+    await waitFor(() => {
+      expect(exportReportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scenarioId: "baseline",
+          reportType: "spend.byVendor",
+          formats: ["csv"]
+        })
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText("Export format"), {
+      target: { value: "pdf" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Queue export" }));
+    await waitFor(() => {
+      expect(exportReportMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scenarioId: "baseline",
+          reportType: "spend.byVendor",
+          formats: ["pdf"]
+        })
+      );
+    });
+
+    expect(await screen.findByText(/C:\\exports\\report\.csv/i)).toBeInTheDocument();
+    expect(await screen.findByText(/C:\\exports\\report\.pdf/i)).toBeInTheDocument();
+    expect(screen.getAllByText("succeeded").length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/renderer/src/features/reports/reports-config-model.test.ts
+++ b/apps/renderer/src/features/reports/reports-config-model.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_REPORT_PRESETS,
+  deserializeReportPreset,
+  loadSavedReportPresets,
+  saveReportPreset,
+  serializeReportPreset,
+  type ReportPreset
+} from "./reports-config-model";
+
+class MemoryStorage {
+  private data = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+}
+
+describe("reports config model", () => {
+  it("serializes and deserializes report presets and keeps defaults complete", () => {
+    expect(DEFAULT_REPORT_PRESETS.length).toBeGreaterThanOrEqual(5);
+    const serialized = serializeReportPreset(DEFAULT_REPORT_PRESETS[0]);
+    const deserialized = deserializeReportPreset(serialized);
+    expect(deserialized).toEqual(DEFAULT_REPORT_PRESETS[0]);
+  });
+
+  it("saves and reloads presets from storage with replace-on-id behavior", () => {
+    const storage = new MemoryStorage();
+    const preset: ReportPreset = {
+      id: "custom-vendor",
+      title: "Custom Vendor",
+      description: "Custom saved preset",
+      query: "spend.byVendor",
+      visualizations: {
+        table: true,
+        chart: true,
+        gauge: false,
+        narrative: false
+      }
+    };
+    saveReportPreset(preset, storage);
+
+    const updatedPreset: ReportPreset = {
+      ...preset,
+      title: "Custom Vendor Updated",
+      visualizations: {
+        table: true,
+        chart: false,
+        gauge: true,
+        narrative: false
+      }
+    };
+    saveReportPreset(updatedPreset, storage);
+
+    const loaded = loadSavedReportPresets(storage);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toEqual(updatedPreset);
+  });
+});

--- a/apps/renderer/src/features/reports/reports-config-model.ts
+++ b/apps/renderer/src/features/reports/reports-config-model.ts
@@ -1,0 +1,137 @@
+export type ReportPreset = {
+  id: string;
+  title: string;
+  description: string;
+  query: string;
+  visualizations: {
+    table: boolean;
+    chart: boolean;
+    gauge: boolean;
+    narrative: boolean;
+  };
+};
+
+const SAVED_REPORTS_KEY = "budgetit.saved-report-presets.v1";
+
+export const DEFAULT_REPORT_PRESETS: ReportPreset[] = [
+  {
+    id: "dashboard-overview",
+    title: "Dashboard Overview",
+    description: "Executive summary of spend, renewals, and replacement health.",
+    query: "dashboard.summary",
+    visualizations: { table: true, chart: true, gauge: true, narrative: true }
+  },
+  {
+    id: "renewals-pipeline",
+    title: "Renewals Pipeline",
+    description: "Upcoming renewals and notice windows grouped by month.",
+    query: "renewals.timeline",
+    visualizations: { table: true, chart: true, gauge: false, narrative: true }
+  },
+  {
+    id: "spend-by-tag",
+    title: "Spend by Tag",
+    description: "Spend distribution by required dimensions and tags.",
+    query: "spend.byTag",
+    visualizations: { table: true, chart: true, gauge: false, narrative: false }
+  },
+  {
+    id: "spend-by-vendor",
+    title: "Spend by Vendor",
+    description: "Vendor concentration and trend breakdown.",
+    query: "spend.byVendor",
+    visualizations: { table: true, chart: true, gauge: true, narrative: false }
+  },
+  {
+    id: "replacement-pipeline",
+    title: "Replacement Pipeline",
+    description: "Replacement required pipeline and plan progression.",
+    query: "replacement.pipeline",
+    visualizations: { table: true, chart: false, gauge: true, narrative: true }
+  },
+  {
+    id: "tagging-completeness",
+    title: "Tagging Completeness",
+    description: "Tag coverage and required-dimension completion.",
+    query: "tagging.completeness",
+    visualizations: { table: true, chart: false, gauge: true, narrative: true }
+  }
+];
+
+export function serializeReportPreset(preset: ReportPreset): string {
+  return JSON.stringify(preset);
+}
+
+export function deserializeReportPreset(raw: string): ReportPreset | null {
+  try {
+    const parsed = JSON.parse(raw) as ReportPreset;
+    return isReportPreset(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function loadSavedReportPresets(
+  storage: Pick<Storage, "getItem"> | null | undefined = getStorage()
+): ReportPreset[] {
+  if (!storage) {
+    return [];
+  }
+  const raw = storage.getItem(SAVED_REPORTS_KEY);
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown[];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(isReportPreset);
+  } catch {
+    return [];
+  }
+}
+
+export function saveReportPreset(
+  preset: ReportPreset,
+  storage: Pick<Storage, "getItem" | "setItem"> | null | undefined = getStorage()
+): ReportPreset[] {
+  if (!storage) {
+    return [preset];
+  }
+  const existing = loadSavedReportPresets(storage);
+  const next = mergeReportPreset(existing, preset);
+  storage.setItem(SAVED_REPORTS_KEY, JSON.stringify(next));
+  return next;
+}
+
+function mergeReportPreset(existing: ReportPreset[], preset: ReportPreset): ReportPreset[] {
+  const withoutMatch = existing.filter((entry) => entry.id !== preset.id);
+  return [...withoutMatch, preset];
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null;
+  }
+  return window.localStorage;
+}
+
+function isReportPreset(value: unknown): value is ReportPreset {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const input = value as Record<string, unknown>;
+  const viz = input.visualizations as Record<string, unknown> | undefined;
+  return (
+    typeof input.id === "string" &&
+    typeof input.title === "string" &&
+    typeof input.description === "string" &&
+    typeof input.query === "string" &&
+    viz !== undefined &&
+    typeof viz.table === "boolean" &&
+    typeof viz.chart === "boolean" &&
+    typeof viz.gauge === "boolean" &&
+    typeof viz.narrative === "boolean"
+  );
+}


### PR DESCRIPTION
## Summary
- expand Reports into a dedicated gallery + workspace flow with predefined report presets and open actions
- add configurable workspace filters (scenario/date/tag) plus visualization block toggles (table/chart/gauge/narrative)
- implement saveable report preset model with serialization/deserialization and local preset persistence
- add export orchestration with destination confirmation, queued job tracking, status, and output paths in a structured panel
- add renderer tests for config model, filter-driven refresh behavior, and full export flow across two formats

## Testing
- npm run lint --workspace @budgetit/renderer
- npm run typecheck --workspace @budgetit/renderer
- npm run test --workspace @budgetit/renderer
- npm run build --workspace @budgetit/renderer

Closes #67