### PR TITLE
[U12] NLQ workspace with history, preview, table, and save-as-report

### DIFF
--- a/apps/renderer/src/features/nlq/NlqPage.css
+++ b/apps/renderer/src/features/nlq/NlqPage.css
@@ -1,0 +1,54 @@
+.nlq-page {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem 1.25rem;
+}
+
+.nlq-page__prompt {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.nlq-page__examples {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.nlq-page__history {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.nlq-page__history li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.nlq-page__filter-preview {
+  background: #f6f8fa;
+  border: 1px solid #d1d9e0;
+  border-radius: 8px;
+  padding: 0.6rem;
+  margin: 0.45rem 0 0;
+  overflow-x: auto;
+}
+
+.nlq-page__actions,
+.nlq-page__save-report {
+  margin-top: 0.55rem;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+}
+
+@media (max-width: 860px) {
+  .nlq-page__prompt {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/apps/renderer/src/features/nlq/NlqPage.test.tsx
+++ b/apps/renderer/src/features/nlq/NlqPage.test.tsx
@@ -1,0 +1,156 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DashboardDataset } from "../../reporting";
+import { AppShell } from "../../app/AppShell";
+import { AppRoutes } from "../../app/routes";
+import { exportReport, parseNlq, queryReport } from "../../lib/ipcClient";
+import { budgetItLightTheme } from "../../ui/theme";
+import { ScenarioProvider } from "../scenarios/ScenarioContext";
+import { NlqPage } from "./NlqPage";
+
+vi.mock("../../lib/ipcClient", () => ({
+  parseNlq: vi.fn(),
+  exportReport: vi.fn(),
+  queryReport: vi.fn()
+}));
+
+const parseNlqMock = vi.mocked(parseNlq);
+const exportReportMock = vi.mocked(exportReport);
+const queryReportMock = vi.mocked(queryReport);
+
+const reportDataset: DashboardDataset = {
+  scenarioId: "baseline",
+  staleForecast: false,
+  spendTrend: [{ month: "2026-01", forecastMinor: 10000, actualMinor: 9900 }],
+  variance: [
+    {
+      month: "2026-01",
+      forecastMinor: 10000,
+      actualMinor: 9900,
+      varianceMinor: -100,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    }
+  ],
+  renewals: [{ month: "2026-06", count: 1 }],
+  growth: [{ month: "2026-01", forecastMinor: 10000, growthPct: null }],
+  taggingCompleteness: {
+    totalExpenseLines: 10,
+    taggedExpenseLines: 9,
+    completenessRatio: 0.9
+  },
+  replacementStatus: {
+    totalPlans: 2,
+    replacementRequiredOpen: 1,
+    byStatus: [{ status: "draft", count: 2 }]
+  },
+  narrativeBlocks: [{ id: "summary", title: "Summary", body: "Narrative" }]
+};
+
+function renderNlqStandalone() {
+  return render(
+    <FluentProvider theme={budgetItLightTheme}>
+      <MemoryRouter>
+        <NlqPage />
+      </MemoryRouter>
+    </FluentProvider>
+  );
+}
+
+function renderWorkspace(initialPath: string) {
+  return render(
+    <ScenarioProvider>
+      <FluentProvider theme={budgetItLightTheme}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <AppShell>
+            <AppRoutes />
+          </AppShell>
+        </MemoryRouter>
+      </FluentProvider>
+    </ScenarioProvider>
+  );
+}
+
+describe("NlqPage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    parseNlqMock.mockReset();
+    exportReportMock.mockReset();
+    queryReportMock.mockReset();
+    parseNlqMock.mockResolvedValue({
+      filterSpec: {
+        dateWindow: "next_90_days",
+        vendor: "Microsoft",
+        amount: { op: ">", value: 50000 }
+      },
+      explanation: "Parsed filters: vendor Microsoft, amount > 50000, next 90 days.",
+      rows: [
+        { id: "exp-1", name: "Endpoint Security", amount_minor: 84000 },
+        { id: "exp-2", name: "Cloud Compute", amount_minor: 240000 }
+      ]
+    });
+    exportReportMock.mockResolvedValue({
+      files: { csv: "C:\\exports\\nlq-results.csv", excel: "C:\\exports\\nlq-results.xlsx" }
+    });
+    queryReportMock.mockResolvedValue(reportDataset);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("maps nlq.parse response into filter preview and result table", async () => {
+    renderNlqStandalone();
+
+    fireEvent.change(screen.getByLabelText("NLQ prompt input"), {
+      target: { value: "show microsoft spend over 50000 in next 90 days" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+
+    await waitFor(() => {
+      expect(parseNlqMock).toHaveBeenCalledWith({
+        query: "show microsoft spend over 50000 in next 90 days"
+      });
+    });
+
+    expect(
+      await screen.findByText(
+        "Parsed filters: vendor Microsoft, amount > 50000, next 90 days."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/"vendor": "Microsoft"/i)).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "NLQ results table" })).toBeInTheDocument();
+    expect(screen.getByText("Endpoint Security")).toBeInTheDocument();
+    expect(screen.getByText("Cloud Compute")).toBeInTheDocument();
+  });
+
+  it("runs prompt, saves as report, and reopens saved preset in report gallery", async () => {
+    renderWorkspace("/nlq");
+
+    fireEvent.change(screen.getByLabelText("NLQ prompt input"), {
+      target: { value: "security variance this quarter" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run query" }));
+    await screen.findByText(/Parsed filters:/i);
+
+    fireEvent.change(screen.getByLabelText("Save report name"), {
+      target: { value: "Security Variance Report" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save as report" }));
+    expect(await screen.findByText("Saved report preset: Security Variance Report.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("link", { name: "Reports" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Reports");
+    });
+    expect(
+      screen.getByRole("button", { name: "Open Security Variance Report" })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/renderer/src/features/nlq/NlqPage.tsx
+++ b/apps/renderer/src/features/nlq/NlqPage.tsx
@@ -1,11 +1,309 @@
-import { FeaturePlaceholderPage } from "../common/FeaturePlaceholderPage";
+import { useMemo, useState } from "react";
+import {
+  Button,
+  Card,
+  Input,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Text,
+  Title3
+} from "@fluentui/react-components";
+
+import { exportReport, parseNlq } from "../../lib/ipcClient";
+import { InlineError, PageHeader } from "../../ui/primitives";
+import { saveReportPreset } from "../reports/reports-config-model";
+import { useScenarioContext } from "../scenarios/ScenarioContext";
+import {
+  addNlqHistoryEntry,
+  loadNlqHistory,
+  persistNlqHistory
+} from "./nlq-history-model";
+import "./NlqPage.css";
+
+type ResultSortKey = "name" | "amount_minor";
+type ResultSortDirection = "asc" | "desc";
+type ExportFormat = "csv" | "excel";
+
+const PROFILE_ID = "default-profile";
+const EXAMPLE_QUERIES = [
+  "show renewals in next 90 days",
+  "forecast spend above $1000 tagged security",
+  "variance for finance services this quarter"
+];
+
+function sortResults(
+  rows: Array<{ id: string; name: string; amount_minor: number }>,
+  sortKey: ResultSortKey,
+  direction: ResultSortDirection
+): Array<{ id: string; name: string; amount_minor: number }> {
+  const multiplier = direction === "asc" ? 1 : -1;
+  return [...rows].sort((left, right) => {
+    if (sortKey === "amount_minor") {
+      return (left.amount_minor - right.amount_minor) * multiplier;
+    }
+    return left.name.localeCompare(right.name) * multiplier;
+  });
+}
 
 export function NlqPage() {
+  const { selectedScenarioId } = useScenarioContext();
+  const [queryInput, setQueryInput] = useState("");
+  const [history, setHistory] = useState(() => loadNlqHistory(PROFILE_ID));
+  const [result, setResult] = useState<{
+    filterSpec: Record<string, unknown>;
+    explanation: string;
+    rows: Array<{ id: string; name: string; amount_minor: number }>;
+  } | null>(null);
+  const [sortKey, setSortKey] = useState<ResultSortKey>("name");
+  const [sortDirection, setSortDirection] = useState<ResultSortDirection>("asc");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pageMessage, setPageMessage] = useState<string | null>(null);
+  const [saveReportName, setSaveReportName] = useState("");
+  const [exportFormat, setExportFormat] = useState<ExportFormat>("csv");
+  const [exportPath, setExportPath] = useState("C:\\exports");
+
+  const sortedRows = useMemo(() => {
+    if (!result) {
+      return [];
+    }
+    return sortResults(result.rows, sortKey, sortDirection);
+  }, [result, sortDirection, sortKey]);
+
+  async function runQuery(query: string): Promise<void> {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      setError("Enter a query before running NLQ.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setPageMessage(null);
+    try {
+      const parsed = await parseNlq({
+        query: trimmed
+      });
+      setResult(parsed);
+      const nextHistory = addNlqHistoryEntry(history, trimmed, new Date().toISOString());
+      setHistory(nextHistory);
+      persistNlqHistory(PROFILE_ID, nextHistory);
+      setQueryInput(trimmed);
+      setPageMessage(`Query matched ${parsed.rows.length} row(s).`);
+    } catch (nextError) {
+      const detail = nextError instanceof Error ? nextError.message : String(nextError);
+      setError(`NLQ parse failed: ${detail}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function exportResults(): Promise<void> {
+    if (!result) {
+      setError("Run an NLQ query before exporting.");
+      return;
+    }
+    setError(null);
+    try {
+      const exported = await exportReport({
+        scenarioId: selectedScenarioId,
+        reportType: "nlq.results",
+        formats: [exportFormat],
+        destinationPath: exportPath,
+        filterSpec: result.filterSpec
+      });
+      const output = exported.files[exportFormat];
+      setPageMessage(output ? `Exported to ${output}` : "Export completed.");
+    } catch (nextError) {
+      const detail = nextError instanceof Error ? nextError.message : String(nextError);
+      setError(`Export failed: ${detail}`);
+    }
+  }
+
+  function saveAsReport(): void {
+    if (!result) {
+      setError("Run an NLQ query before saving a report preset.");
+      return;
+    }
+    const trimmedName = saveReportName.trim();
+    if (!trimmedName) {
+      setError("Provide a report name before saving.");
+      return;
+    }
+
+    const id = trimmedName
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    saveReportPreset({
+      id,
+      title: trimmedName,
+      description: `Saved from NLQ: ${queryInput}`,
+      query: "nlq.saved",
+      visualizations: {
+        table: true,
+        chart: false,
+        gauge: false,
+        narrative: true
+      }
+    });
+    setPageMessage(`Saved report preset: ${trimmedName}.`);
+  }
+
+  function toggleSort(nextSortKey: ResultSortKey): void {
+    if (sortKey === nextSortKey) {
+      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortKey(nextSortKey);
+    setSortDirection("asc");
+  }
+
   return (
-    <FeaturePlaceholderPage
-      title="NLQ"
-      description="NLQ workspace with query history, parsed filters, results table, and save-as-report is planned in U12."
-    />
+    <section className="nlq-page">
+      <PageHeader
+        title="NLQ Workspace"
+        subtitle="Run natural language queries, inspect parsed filters, and convert results to reusable reports."
+      />
+
+      <Card>
+        <Title3>Prompt</Title3>
+        <div className="nlq-page__prompt">
+          <Input
+            aria-label="NLQ prompt input"
+            value={queryInput}
+            onChange={(_event, data) => setQueryInput(data.value)}
+            placeholder="Ask a budgeting question..."
+          />
+          <Button appearance="primary" disabled={loading} onClick={() => void runQuery(queryInput)}>
+            {loading ? "Running..." : "Run query"}
+          </Button>
+        </div>
+        <div className="nlq-page__examples">
+          {EXAMPLE_QUERIES.map((query) => (
+            <Button
+              key={query}
+              size="small"
+              appearance="secondary"
+              onClick={() => setQueryInput(query)}
+            >
+              {query}
+            </Button>
+          ))}
+        </div>
+      </Card>
+
+      <Card>
+        <Title3>Query History</Title3>
+        {history.length === 0 ? (
+          <Text>No history yet.</Text>
+        ) : (
+          <ul className="nlq-page__history">
+            {history.map((entry) => (
+              <li key={`${entry.query}-${entry.lastRunAt}`}>
+                <Button
+                  size="small"
+                  appearance="secondary"
+                  onClick={() => void runQuery(entry.query)}
+                >
+                  {entry.query}
+                </Button>
+                <Text>{`runs: ${entry.runCount}`}</Text>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      {result ? (
+        <>
+          <Card>
+            <Title3>Parsed FilterSpec</Title3>
+            <Text>{result.explanation}</Text>
+            <pre className="nlq-page__filter-preview">
+              {JSON.stringify(result.filterSpec, null, 2)}
+            </pre>
+          </Card>
+
+          <Card>
+            <Title3>Matched Rows</Title3>
+            <Table aria-label="NLQ results table">
+              <TableHeader>
+                <TableRow>
+                  <TableHeaderCell>ID</TableHeaderCell>
+                  <TableHeaderCell>
+                    <Button size="small" appearance="subtle" onClick={() => toggleSort("name")}>
+                      Name
+                    </Button>
+                  </TableHeaderCell>
+                  <TableHeaderCell>
+                    <Button
+                      size="small"
+                      appearance="subtle"
+                      onClick={() => toggleSort("amount_minor")}
+                    >
+                      Amount
+                    </Button>
+                  </TableHeaderCell>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sortedRows.map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell>{row.id}</TableCell>
+                    <TableCell>{row.name}</TableCell>
+                    <TableCell>{row.amount_minor}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+
+            <div className="nlq-page__actions">
+              <Select
+                aria-label="NLQ export format"
+                value={exportFormat}
+                onChange={(event) => setExportFormat(event.target.value as ExportFormat)}
+              >
+                <option value="csv">CSV</option>
+                <option value="excel">Excel</option>
+              </Select>
+              <Input
+                aria-label="NLQ export path"
+                value={exportPath}
+                onChange={(_event, data) => setExportPath(data.value)}
+                placeholder="C:\\exports"
+              />
+              <Button appearance="secondary" onClick={() => void exportResults()}>
+                Export results
+              </Button>
+            </div>
+          </Card>
+
+          <Card>
+            <Title3>Save as Report</Title3>
+            <div className="nlq-page__save-report">
+              <Input
+                aria-label="Save report name"
+                value={saveReportName}
+                onChange={(_event, data) => setSaveReportName(data.value)}
+                placeholder="Quarterly security variance"
+              />
+              <Button appearance="primary" onClick={saveAsReport}>
+                Save as report
+              </Button>
+            </div>
+          </Card>
+        </>
+      ) : null}
+
+      {error ? <InlineError message={error} /> : null}
+      {pageMessage ? <Text>{pageMessage}</Text> : null}
+    </section>
   );
 }
 

--- a/apps/renderer/src/features/nlq/nlq-history-model.test.ts
+++ b/apps/renderer/src/features/nlq/nlq-history-model.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addNlqHistoryEntry,
+  loadNlqHistory,
+  persistNlqHistory,
+  type NlqHistoryEntry
+} from "./nlq-history-model";
+
+class MemoryStorage {
+  private data = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+}
+
+describe("nlq history model", () => {
+  it("collapses duplicate queries and increments run counts", () => {
+    const first = addNlqHistoryEntry([], "Spend by vendor", "2026-02-27T10:00:00.000Z");
+    const second = addNlqHistoryEntry(
+      first,
+      "spend by vendor",
+      "2026-02-27T10:05:00.000Z"
+    );
+    expect(second).toHaveLength(1);
+    expect(second[0].runCount).toBe(2);
+    expect(second[0].lastRunAt).toBe("2026-02-27T10:05:00.000Z");
+  });
+
+  it("persists and reloads history by profile id", () => {
+    const storage = new MemoryStorage();
+    const history: NlqHistoryEntry[] = [
+      {
+        query: "renewals in next 90 days",
+        lastRunAt: "2026-02-27T10:10:00.000Z",
+        runCount: 1
+      }
+    ];
+
+    persistNlqHistory("default-profile", history, storage);
+    expect(loadNlqHistory("default-profile", storage)).toEqual(history);
+  });
+});

--- a/apps/renderer/src/features/nlq/nlq-history-model.ts
+++ b/apps/renderer/src/features/nlq/nlq-history-model.ts
@@ -1,0 +1,95 @@
+export type NlqHistoryEntry = {
+  query: string;
+  lastRunAt: string;
+  runCount: number;
+};
+
+const HISTORY_KEY_PREFIX = "budgetit.nlq-history.v1";
+
+export function addNlqHistoryEntry(
+  history: NlqHistoryEntry[],
+  query: string,
+  timestamp: string,
+  maxEntries = 12
+): NlqHistoryEntry[] {
+  const normalized = normalizeQuery(query);
+  const existing = history.find((entry) => normalizeQuery(entry.query) === normalized);
+  const withoutCurrent = history.filter(
+    (entry) => normalizeQuery(entry.query) !== normalized
+  );
+
+  const nextEntry: NlqHistoryEntry = existing
+    ? {
+        ...existing,
+        query: query.trim(),
+        lastRunAt: timestamp,
+        runCount: existing.runCount + 1
+      }
+    : {
+        query: query.trim(),
+        lastRunAt: timestamp,
+        runCount: 1
+      };
+
+  return [nextEntry, ...withoutCurrent].slice(0, maxEntries);
+}
+
+export function loadNlqHistory(
+  profileId: string,
+  storage: Pick<Storage, "getItem"> | null | undefined = getStorage()
+): NlqHistoryEntry[] {
+  if (!storage) {
+    return [];
+  }
+  const raw = storage.getItem(historyKey(profileId));
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown[];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(isHistoryEntry);
+  } catch {
+    return [];
+  }
+}
+
+export function persistNlqHistory(
+  profileId: string,
+  history: NlqHistoryEntry[],
+  storage: Pick<Storage, "setItem"> | null | undefined = getStorage()
+): void {
+  if (!storage) {
+    return;
+  }
+  storage.setItem(historyKey(profileId), JSON.stringify(history));
+}
+
+function historyKey(profileId: string): string {
+  return `${HISTORY_KEY_PREFIX}:${profileId}`;
+}
+
+function normalizeQuery(query: string): string {
+  return query.trim().toLowerCase();
+}
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null;
+  }
+  return window.localStorage;
+}
+
+function isHistoryEntry(value: unknown): value is NlqHistoryEntry {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const input = value as Record<string, unknown>;
+  return (
+    typeof input.query === "string" &&
+    typeof input.lastRunAt === "string" &&
+    typeof input.runCount === "number"
+  );
+}


### PR DESCRIPTION
## Summary\n- implement NLQ workspace UI with prompt execution, examples, filter preview, sortable result table, and export actions\n- add persisted NLQ query history model with duplicate collapse/run-count behavior\n- add save-as-report flow from NLQ to reports gallery presets\n\n## Test Plan\n- npm run lint --workspace @budgetit/renderer\n- npm run typecheck --workspace @budgetit/renderer\n- npm run test --workspace @budgetit/renderer\n- npm run build --workspace @budgetit/renderer\n\nCloses #68