### PR TITLE
[U14] Command palette, global search, keyboard-first navigation

### DIFF
--- a/apps/renderer/src/app/AppShell.css
+++ b/apps/renderer/src/app/AppShell.css
@@ -49,7 +49,7 @@
   border-bottom: 1px solid #d1d9e0;
   padding: 0.75rem 1rem;
   display: grid;
-  grid-template-columns: 1fr auto auto auto;
+  grid-template-columns: 1fr auto minmax(15rem, 1fr) auto auto;
   gap: 0.75rem;
   align-items: center;
   background: #ffffff;
@@ -76,6 +76,62 @@
   cursor: pointer;
 }
 
+.desktop-shell__feedback {
+  border-bottom: 1px solid #d1d9e0;
+  background: #ecfdf3;
+  color: #166534;
+  padding: 0.4rem 1rem;
+}
+
+.desktop-shell__feedback--error {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.desktop-shell__command-list {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.desktop-shell__command-row {
+  width: 100%;
+  border: 1px solid #d1d9e0;
+  background: #fff;
+  border-radius: 8px;
+  padding: 0.45rem 0.55rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: center;
+  cursor: pointer;
+}
+
+.desktop-shell__command-row--active {
+  border-color: #60a5fa;
+  background: #eff6ff;
+}
+
+.desktop-shell__command-shortcut {
+  color: #4b5563;
+  font-size: 0.82rem;
+}
+
+.desktop-shell__command-hint {
+  margin-top: 0.75rem;
+  display: block;
+  color: #57606a;
+}
+
+.desktop-shell__keyboard-map {
+  margin: 0;
+  padding-left: 1rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
 .desktop-shell__page {
   overflow: auto;
   background: #ffffff;
@@ -91,5 +147,9 @@
     border-bottom: 1px solid #d1d9e0;
     grid-auto-flow: column;
     overflow-x: auto;
+  }
+
+  .desktop-shell__topbar {
+    grid-template-columns: 1fr minmax(0, 1fr);
   }
 }

--- a/apps/renderer/src/app/AppShell.tsx
+++ b/apps/renderer/src/app/AppShell.tsx
@@ -1,15 +1,260 @@
-import type { PropsWithChildren } from "react";
-import { Button, Input, Select, Text } from "@fluentui/react-components";
-import { NavLink, useLocation } from "react-router-dom";
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type PropsWithChildren } from "react";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  Input,
+  Select,
+  Text
+} from "@fluentui/react-components";
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
 
+import { CONTRACT_RECORDS, SERVICE_RECORDS } from "../features/services/service-contract-data";
+import { INITIAL_VENDOR_RECORDS } from "../features/vendors/vendor-data";
 import { useScenarioContext } from "../features/scenarios/ScenarioContext";
+import { createBackup } from "../lib/ipcClient";
+import {
+  COMMAND_REGISTRY,
+  KEYBOARD_SHORTCUT_MAP,
+  resolvePaletteCommands,
+  type CommandActionId,
+  type CommandEntry
+} from "./command-palette-model";
 import { NAV_ROUTES, resolveRouteLabel } from "./routes";
 import "./AppShell.css";
 
+type FeedbackTone = "success" | "error" | "info";
+type ShellFeedback = {
+  tone: FeedbackTone;
+  message: string;
+};
+
+type GlobalSearchEntry = {
+  id: string;
+  label: string;
+  route: string;
+  keywords: string[];
+};
+
+const GLOBAL_SEARCH_ENTRIES: GlobalSearchEntry[] = [
+  ...INITIAL_VENDOR_RECORDS.map((vendor) => ({
+    id: `vendor-${vendor.id}`,
+    label: `Vendor: ${vendor.name}`,
+    route: `/vendors?vendor=${encodeURIComponent(vendor.id)}`,
+    keywords: [vendor.name, "vendor"]
+  })),
+  ...SERVICE_RECORDS.map((service) => ({
+    id: `service-${service.id}`,
+    label: `Service: ${service.name}`,
+    route: `/services?service=${encodeURIComponent(service.id)}`,
+    keywords: [service.name, service.vendorName, "service"]
+  })),
+  ...CONTRACT_RECORDS.map((contract) => ({
+    id: `contract-${contract.id}`,
+    label: `Contract: ${contract.contractNumber}`,
+    route: `/contracts?contract=${encodeURIComponent(contract.id)}`,
+    keywords: [contract.contractNumber, contract.providerName, "contract"]
+  })),
+  {
+    id: "expense-exp-1",
+    label: "Expense: Cloud Compute",
+    route: "/expenses?expense=exp-1",
+    keywords: ["cloud", "expense"]
+  },
+  {
+    id: "expense-exp-2",
+    label: "Expense: Endpoint Security",
+    route: "/expenses?expense=exp-2",
+    keywords: ["security", "expense"]
+  },
+  {
+    id: "expense-exp-3",
+    label: "Expense: Analytics Suite",
+    route: "/expenses?expense=exp-3",
+    keywords: ["analytics", "expense"]
+  }
+];
+
+function resolveGlobalSearchEntries(query: string): GlobalSearchEntry[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return GLOBAL_SEARCH_ENTRIES.slice(0, 10);
+  }
+  return GLOBAL_SEARCH_ENTRIES
+    .filter(
+      (entry) =>
+        entry.label.toLowerCase().includes(normalized) ||
+        entry.keywords.some((keyword) => keyword.toLowerCase().includes(normalized))
+    )
+    .slice(0, 10);
+}
+
+function findCommandByActionId(actionId: CommandActionId): CommandEntry | undefined {
+  return COMMAND_REGISTRY.find(
+    (entry) => entry.intent.kind === "action" && entry.intent.actionId === actionId
+  );
+}
+
 export function AppShell({ children }: PropsWithChildren) {
   const location = useLocation();
+  const navigate = useNavigate();
   const pageTitle = resolveRouteLabel(location.pathname);
   const { scenarios, selectedScenarioId, selectScenario } = useScenarioContext();
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [keyboardHelpOpen, setKeyboardHelpOpen] = useState(false);
+  const [commandQuery, setCommandQuery] = useState("");
+  const [commandCursor, setCommandCursor] = useState(0);
+  const [globalSearchValue, setGlobalSearchValue] = useState("");
+  const [feedback, setFeedback] = useState<ShellFeedback | null>(null);
+  const [commandBusy, setCommandBusy] = useState(false);
+  const paletteInputRef = useRef<HTMLInputElement | null>(null);
+  const globalSearchRef = useRef<HTMLInputElement | null>(null);
+
+  const paletteCommands = useMemo(
+    () => resolvePaletteCommands(commandQuery),
+    [commandQuery]
+  );
+  const globalSearchEntries = useMemo(
+    () => resolveGlobalSearchEntries(globalSearchValue),
+    [globalSearchValue]
+  );
+
+  useEffect(() => {
+    if (!commandPaletteOpen) {
+      return;
+    }
+    setCommandCursor(0);
+    const timeout = window.setTimeout(() => {
+      paletteInputRef.current?.focus();
+    }, 0);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [commandPaletteOpen]);
+
+  useEffect(() => {
+    setCommandCursor(0);
+  }, [commandQuery]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const isMeta = event.ctrlKey || event.metaKey;
+      if (isMeta && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setCommandPaletteOpen(true);
+        return;
+      }
+      if (event.ctrlKey && event.shiftKey && event.key.toLowerCase() === "f") {
+        event.preventDefault();
+        globalSearchRef.current?.focus();
+        return;
+      }
+      if (event.key === "Escape") {
+        if (commandPaletteOpen) {
+          event.preventDefault();
+          setCommandPaletteOpen(false);
+        }
+        if (keyboardHelpOpen) {
+          event.preventDefault();
+          setKeyboardHelpOpen(false);
+        }
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [commandPaletteOpen, keyboardHelpOpen]);
+
+  async function executeCommand(command: CommandEntry): Promise<void> {
+    setCommandPaletteOpen(false);
+    setFeedback(null);
+
+    try {
+      if (command.intent.kind === "route") {
+        navigate(command.intent.to);
+        setFeedback({
+          tone: "success",
+          message: `Opened ${command.label.replace(/^Go to /, "")}.`
+        });
+        return;
+      }
+
+      setCommandBusy(true);
+      switch (command.intent.actionId) {
+        case "new-expense":
+          navigate("/expenses?action=create");
+          setFeedback({ tone: "success", message: "Create Expense command executed." });
+          break;
+        case "run-import":
+          navigate("/import");
+          setFeedback({ tone: "success", message: "Import workspace opened." });
+          break;
+        case "open-alerts":
+          navigate("/alerts?tab=dueSoon");
+          setFeedback({ tone: "success", message: "Alerts inbox opened." });
+          break;
+        case "backup-now": {
+          const created = await createBackup();
+          setFeedback({
+            tone: "success",
+            message: `Backup created: ${created.backupPath}`
+          });
+          break;
+        }
+        case "open-shortcuts":
+          setKeyboardHelpOpen(true);
+          setFeedback({ tone: "info", message: "Keyboard shortcut help opened." });
+          break;
+        default:
+          setFeedback({ tone: "error", message: "Unknown command action." });
+      }
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      setFeedback({ tone: "error", message: `Command failed: ${detail}` });
+    } finally {
+      setCommandBusy(false);
+    }
+  }
+
+  function handlePaletteInputKeyDown(event: ReactKeyboardEvent<HTMLInputElement>): void {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setCommandCursor((current) => Math.min(current + 1, paletteCommands.length - 1));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setCommandCursor((current) => Math.max(current - 1, 0));
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const selected = paletteCommands[commandCursor] ?? paletteCommands[0];
+      if (selected) {
+        void executeCommand(selected);
+      }
+    }
+  }
+
+  function handleGlobalSearchEnter(): void {
+    const normalized = globalSearchValue.trim().toLowerCase();
+    if (!normalized) {
+      return;
+    }
+    const selected =
+      globalSearchEntries.find((entry) => entry.label.toLowerCase() === normalized) ??
+      globalSearchEntries[0];
+    if (!selected) {
+      setFeedback({ tone: "error", message: "No matching entity was found." });
+      return;
+    }
+    navigate(selected.route);
+    setFeedback({ tone: "success", message: `Opened ${selected.label}.` });
+  }
 
   return (
     <div className="desktop-shell">
@@ -55,16 +300,131 @@ export function AppShell({ children }: PropsWithChildren) {
           <Input
             aria-label="Global search"
             className="desktop-shell__toolbar-input"
-            placeholder="Search (Ctrl+K)"
+            list="global-search-options"
+            placeholder="Search entities (Ctrl+Shift+F)"
+            ref={globalSearchRef}
             type="search"
+            value={globalSearchValue}
+            onChange={(_event, data) => setGlobalSearchValue(data.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                handleGlobalSearchEnter();
+              }
+            }}
           />
-          <Button appearance="secondary" className="desktop-shell__toolbar-button" type="button">
+          <datalist id="global-search-options">
+            {globalSearchEntries.map((entry) => (
+              <option key={entry.id} value={entry.label} />
+            ))}
+          </datalist>
+          <Button
+            appearance="secondary"
+            className="desktop-shell__toolbar-button"
+            onClick={() => setCommandPaletteOpen(true)}
+            type="button"
+          >
+            Command Palette
+          </Button>
+          <Button
+            appearance="secondary"
+            className="desktop-shell__toolbar-button"
+            disabled={commandBusy}
+            onClick={() => {
+              const command = findCommandByActionId("new-expense");
+              if (command) {
+                void executeCommand(command);
+              }
+            }}
+            type="button"
+          >
             Create
           </Button>
         </header>
+        {feedback ? (
+          <div
+            className={
+              feedback.tone === "error"
+                ? "desktop-shell__feedback desktop-shell__feedback--error"
+                : "desktop-shell__feedback"
+            }
+            role="status"
+          >
+            <Text>{feedback.message}</Text>
+          </div>
+        ) : null}
         <main className="desktop-shell__page">{children}</main>
       </div>
+
+      <Dialog
+        open={commandPaletteOpen}
+        onOpenChange={(_event, data) => setCommandPaletteOpen(data.open)}
+      >
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Command Palette</DialogTitle>
+            <DialogContent>
+              <Input
+                aria-label="Command palette input"
+                placeholder="Type a command..."
+                ref={paletteInputRef}
+                value={commandQuery}
+                onChange={(_event, data) => setCommandQuery(data.value)}
+                onKeyDown={handlePaletteInputKeyDown}
+              />
+              <ul
+                className="desktop-shell__command-list"
+                aria-label="Command results"
+                role="listbox"
+              >
+                {paletteCommands.slice(0, 8).map((command, index) => (
+                  <li key={command.id} role="option" aria-selected={index === commandCursor}>
+                    <button
+                      className={
+                        index === commandCursor
+                          ? "desktop-shell__command-row desktop-shell__command-row--active"
+                          : "desktop-shell__command-row"
+                      }
+                      onClick={() => {
+                        void executeCommand(command);
+                      }}
+                      type="button"
+                    >
+                      <span>{command.label}</span>
+                      {command.shortcut ? (
+                        <span className="desktop-shell__command-shortcut">{command.shortcut}</span>
+                      ) : null}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <Text className="desktop-shell__command-hint">
+                {`${KEYBOARD_SHORTCUT_MAP.palettePrevious}/${KEYBOARD_SHORTCUT_MAP.paletteNext} to navigate, ${KEYBOARD_SHORTCUT_MAP.executeCommand} to run.`}
+              </Text>
+            </DialogContent>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+
+      <Dialog
+        open={keyboardHelpOpen}
+        onOpenChange={(_event, data) => setKeyboardHelpOpen(data.open)}
+      >
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Keyboard Map</DialogTitle>
+            <DialogContent>
+              <ul className="desktop-shell__keyboard-map">
+                <li>{`${KEYBOARD_SHORTCUT_MAP.openPalette}: Open command palette`}</li>
+                <li>{`${KEYBOARD_SHORTCUT_MAP.focusGlobalSearch}: Focus global search`}</li>
+                <li>{`${KEYBOARD_SHORTCUT_MAP.closeDialog}: Close active dialog`}</li>
+                <li>{`${KEYBOARD_SHORTCUT_MAP.executeCommand}: Execute selected command`}</li>
+                <li>{`${KEYBOARD_SHORTCUT_MAP.palettePrevious}/${KEYBOARD_SHORTCUT_MAP.paletteNext}: Move through command list`}</li>
+              </ul>
+            </DialogContent>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
     </div>
   );
 }
-

--- a/apps/renderer/src/app/command-palette-model.test.ts
+++ b/apps/renderer/src/app/command-palette-model.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COMMAND_REGISTRY,
+  KEYBOARD_SHORTCUT_MAP,
+  resolvePaletteCommands
+} from "./command-palette-model";
+
+describe("command palette model", () => {
+  it("resolves commands by label and keyword relevance", () => {
+    const backupMatches = resolvePaletteCommands("backup");
+    expect(backupMatches[0]?.id).toBe("action-backup-now");
+
+    const vendorMatches = resolvePaletteCommands("vendors");
+    expect(vendorMatches.some((entry) => entry.id === "route-vendors")).toBe(true);
+  });
+
+  it("covers required action commands and keyboard shortcut map", () => {
+    const actionIds = COMMAND_REGISTRY
+      .map((entry) => (entry.intent.kind === "action" ? entry.intent.actionId : null))
+      .filter((actionId): actionId is NonNullable<typeof actionId> => actionId !== null);
+    expect(actionIds).toEqual(
+      expect.arrayContaining([
+        "new-expense",
+        "run-import",
+        "open-alerts",
+        "backup-now"
+      ])
+    );
+    expect(KEYBOARD_SHORTCUT_MAP.openPalette).toBe("Ctrl+K");
+    expect(KEYBOARD_SHORTCUT_MAP.focusGlobalSearch).toBe("Ctrl+Shift+F");
+  });
+});

--- a/apps/renderer/src/app/command-palette-model.ts
+++ b/apps/renderer/src/app/command-palette-model.ts
@@ -1,0 +1,114 @@
+export type CommandActionId =
+  | "new-expense"
+  | "run-import"
+  | "open-alerts"
+  | "backup-now"
+  | "open-shortcuts";
+
+export type CommandIntent =
+  | {
+      kind: "route";
+      to: string;
+    }
+  | {
+      kind: "action";
+      actionId: CommandActionId;
+    };
+
+export type CommandEntry = {
+  id: string;
+  label: string;
+  keywords: string[];
+  shortcut?: string;
+  intent: CommandIntent;
+};
+
+export const KEYBOARD_SHORTCUT_MAP = {
+  openPalette: "Ctrl+K",
+  focusGlobalSearch: "Ctrl+Shift+F",
+  closeDialog: "Escape",
+  executeCommand: "Enter",
+  paletteNext: "ArrowDown",
+  palettePrevious: "ArrowUp"
+} as const;
+
+export const COMMAND_REGISTRY: CommandEntry[] = [
+  { id: "route-dashboard", label: "Go to Dashboard", keywords: ["home", "overview"], intent: { kind: "route", to: "/dashboard" } },
+  { id: "route-expenses", label: "Go to Expenses", keywords: ["costs", "spend"], intent: { kind: "route", to: "/expenses" } },
+  { id: "route-services", label: "Go to Services", keywords: ["lifecycle", "service"], intent: { kind: "route", to: "/services" } },
+  { id: "route-contracts", label: "Go to Contracts", keywords: ["renewals", "notice"], intent: { kind: "route", to: "/contracts" } },
+  { id: "route-vendors", label: "Go to Vendors", keywords: ["suppliers", "providers"], intent: { kind: "route", to: "/vendors" } },
+  { id: "route-tags", label: "Go to Tags & Dimensions", keywords: ["dimensions", "taxonomy"], intent: { kind: "route", to: "/tags" } },
+  { id: "route-scenarios", label: "Go to Scenarios", keywords: ["baseline", "forecast"], intent: { kind: "route", to: "/scenarios" } },
+  { id: "route-alerts", label: "Go to Alerts", keywords: ["inbox", "notifications"], intent: { kind: "route", to: "/alerts" } },
+  { id: "route-import", label: "Go to Import", keywords: ["csv", "xlsx", "wizard"], intent: { kind: "route", to: "/import" } },
+  { id: "route-reports", label: "Go to Reports", keywords: ["exports", "dashboards"], intent: { kind: "route", to: "/reports" } },
+  { id: "route-nlq", label: "Go to NLQ", keywords: ["natural language", "query"], intent: { kind: "route", to: "/nlq" } },
+  { id: "route-settings", label: "Go to Settings", keywords: ["preferences", "configuration"], intent: { kind: "route", to: "/settings" } },
+  {
+    id: "action-new-expense",
+    label: "New Expense",
+    keywords: ["create", "expense", "add"],
+    shortcut: "N",
+    intent: { kind: "action", actionId: "new-expense" }
+  },
+  {
+    id: "action-run-import",
+    label: "Run Import",
+    keywords: ["import", "wizard", "actuals"],
+    intent: { kind: "action", actionId: "run-import" }
+  },
+  {
+    id: "action-open-alerts",
+    label: "Open Alerts Inbox",
+    keywords: ["alerts", "inbox", "due"],
+    intent: { kind: "action", actionId: "open-alerts" }
+  },
+  {
+    id: "action-backup-now",
+    label: "Backup Now",
+    keywords: ["backup", "resilience", "create backup"],
+    intent: { kind: "action", actionId: "backup-now" }
+  },
+  {
+    id: "action-open-shortcuts",
+    label: "Show Keyboard Shortcuts",
+    keywords: ["help", "keyboard", "shortcuts"],
+    intent: { kind: "action", actionId: "open-shortcuts" }
+  }
+];
+
+export function resolvePaletteCommands(
+  query: string,
+  registry: CommandEntry[] = COMMAND_REGISTRY
+): CommandEntry[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return registry;
+  }
+
+  return registry
+    .map((command) => ({
+      command,
+      score: getMatchScore(command, normalized)
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => right.score - left.score)
+    .map((entry) => entry.command);
+}
+
+function getMatchScore(command: CommandEntry, query: string): number {
+  if (command.label.toLowerCase() === query) {
+    return 100;
+  }
+  if (command.label.toLowerCase().startsWith(query)) {
+    return 80;
+  }
+  if (command.label.toLowerCase().includes(query)) {
+    return 60;
+  }
+  if (command.keywords.some((keyword) => keyword.toLowerCase().includes(query))) {
+    return 40;
+  }
+  return 0;
+}

--- a/apps/renderer/src/app/command-palette.test.tsx
+++ b/apps/renderer/src/app/command-palette.test.tsx
@@ -1,0 +1,113 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppShell } from "./AppShell";
+import { AppRoutes } from "./routes";
+import { budgetItLightTheme } from "../ui/theme";
+import { createBackup } from "../lib/ipcClient";
+import { ScenarioProvider } from "../features/scenarios/ScenarioContext";
+
+vi.mock("../lib/ipcClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/ipcClient")>();
+  return {
+    ...actual,
+    createBackup: vi.fn()
+  };
+});
+
+const createBackupMock = vi.mocked(createBackup);
+
+function renderWorkspace(initialPath = "/dashboard") {
+  return render(
+    <ScenarioProvider>
+      <FluentProvider theme={budgetItLightTheme}>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <AppShell>
+            <AppRoutes />
+          </AppShell>
+        </MemoryRouter>
+      </FluentProvider>
+    </ScenarioProvider>
+  );
+}
+
+describe("command palette and keyboard navigation", () => {
+  beforeEach(() => {
+    createBackupMock.mockReset();
+    createBackupMock.mockResolvedValue({
+      backupPath: "C:\\Backups\\BudgetIT\\backup.db",
+      manifestPath: "C:\\Backups\\BudgetIT\\backup.manifest.json",
+      manifest: {
+        createdAt: "2026-02-27T18:00:00.000Z",
+        sourceLastMutationAt: "2026-02-27T17:55:00.000Z",
+        schemaVersion: 1,
+        checksumSha256: "deadbeef",
+        destinationKind: "local_or_external"
+      }
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("finds and executes action and route commands from palette search", async () => {
+    renderWorkspace();
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    const paletteInput = screen.getByLabelText("Command palette input");
+    fireEvent.change(paletteInput, { target: { value: "backup now" } });
+    fireEvent.keyDown(paletteInput, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(createBackupMock).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Backup created: C:\\Backups\\BudgetIT\\backup.db"
+    );
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    const routeInput = screen.getByLabelText("Command palette input");
+    fireEvent.change(routeInput, { target: { value: "go to alerts" } });
+    fireEvent.keyDown(routeInput, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Alerts");
+    });
+  });
+
+  it("supports keyboard-only flow to open palette and create a new expense", async () => {
+    renderWorkspace("/dashboard");
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    const paletteInput = screen.getByLabelText("Command palette input");
+    fireEvent.change(paletteInput, { target: { value: "new expense" } });
+    fireEvent.keyDown(paletteInput, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Expenses");
+    });
+    expect(await screen.findByLabelText("Expense name")).toBeInTheDocument();
+  });
+
+  it("navigates to entity workspaces from global search", async () => {
+    renderWorkspace("/dashboard");
+
+    fireEvent.change(screen.getByLabelText("Global search"), {
+      target: { value: "Expense: Endpoint Security" }
+    });
+    fireEvent.keyDown(screen.getByLabelText("Global search"), { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("page-title")).toHaveTextContent("Expenses");
+    });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Opened Expense: Endpoint Security."
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- add command palette model with deterministic command registry and keyboard shortcut map\n- implement AppShell command palette dialog, global search, keyboard shortcuts, and action execution feedback\n- add Expenses deep-link/create-action support used by keyboard-first navigation flow\n- add unit and integration tests for palette search, keyboard-only command flow, and global search navigation\n\n## Testing\n- npm run lint --workspace @budgetit/renderer\n- npm run typecheck --workspace @budgetit/renderer\n- npm run test --workspace @budgetit/renderer\n\nCloses #70