### PR TITLE
[U15] UX hardening pass: states, toasts, a11y, and boundaries

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -17,9 +17,11 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "jsdom": "^28.1.0",
-    "vite": "^6.2.1"
+    "vite": "^6.2.1",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/apps/renderer/src/App.css
+++ b/apps/renderer/src/App.css
@@ -75,3 +75,12 @@ p {
   align-items: center;
 }
 
+@keyframes budgetit-loading-wave {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+

--- a/apps/renderer/src/app/accessibility.test.tsx
+++ b/apps/renderer/src/app/accessibility.test.tsx
@@ -1,0 +1,202 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { FluentProvider } from "@fluentui/react-components";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
+
+import { AppRoutes } from "./routes";
+import { AppShell } from "./AppShell";
+import { ScenarioProvider } from "../features/scenarios/ScenarioContext";
+import { FeedbackProvider } from "../ui/feedback";
+import { budgetItLightTheme } from "../ui/theme";
+import {
+  getDatabaseSecurityStatus,
+  getSettings,
+  listAlerts,
+  onAlertNavigate,
+  queryReport
+} from "../lib/ipcClient";
+
+vi.mock("../lib/ipcClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/ipcClient")>();
+  return {
+    ...actual,
+    listAlerts: vi.fn(),
+    onAlertNavigate: vi.fn(),
+    queryReport: vi.fn(),
+    getSettings: vi.fn(),
+    getDatabaseSecurityStatus: vi.fn()
+  };
+});
+
+const listAlertsMock = vi.mocked(listAlerts);
+const onAlertNavigateMock = vi.mocked(onAlertNavigate);
+const queryReportMock = vi.mocked(queryReport);
+const getSettingsMock = vi.mocked(getSettings);
+const getDatabaseSecurityStatusMock = vi.mocked(getDatabaseSecurityStatus);
+
+const datasetFixture = {
+  scenarioId: "baseline",
+  staleForecast: false,
+  spendTrend: [{ month: "2026-01", forecastMinor: 12000, actualMinor: 10000 }],
+  variance: [
+    {
+      month: "2026-01",
+      forecastMinor: 12000,
+      actualMinor: 10000,
+      varianceMinor: -2000,
+      unmatchedActualMinor: 0,
+      unmatchedCount: 0
+    }
+  ],
+  renewals: [{ month: "2026-06", count: 2 }],
+  growth: [{ month: "2026-01", forecastMinor: 12000, growthPct: null }],
+  taggingCompleteness: {
+    totalExpenseLines: 4,
+    taggedExpenseLines: 3,
+    completenessRatio: 0.75
+  },
+  replacementStatus: {
+    totalPlans: 2,
+    replacementRequiredOpen: 1,
+    byStatus: [{ status: "draft", count: 2 }]
+  },
+  narrativeBlocks: [{ id: "summary", title: "Summary", body: "Narrative text." }]
+};
+
+function renderWorkspace(initialPath: string) {
+  return render(
+    <ScenarioProvider>
+      <FluentProvider theme={budgetItLightTheme}>
+        <FeedbackProvider>
+          <MemoryRouter initialEntries={[initialPath]}>
+            <AppShell>
+              <AppRoutes />
+            </AppShell>
+          </MemoryRouter>
+        </FeedbackProvider>
+      </FluentProvider>
+    </ScenarioProvider>
+  );
+}
+
+async function waitForTitle(title: string): Promise<void> {
+  await waitFor(() => {
+    expect(screen.getByTestId("page-title")).toHaveTextContent(title);
+  });
+}
+
+describe("accessibility and keyboard reachability", () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      null as unknown as CanvasRenderingContext2D
+    );
+
+    listAlertsMock.mockReset();
+    onAlertNavigateMock.mockReset();
+    queryReportMock.mockReset();
+    getSettingsMock.mockReset();
+    getDatabaseSecurityStatusMock.mockReset();
+
+    listAlertsMock.mockResolvedValue([
+      {
+        id: "alert-1",
+        entityType: "contract",
+        entityId: "ctr-1",
+        fireAt: "2026-06-20",
+        status: "pending",
+        snoozedUntil: null,
+        message: "Renewal due in 45 days"
+      }
+    ]);
+    onAlertNavigateMock.mockReturnValue(undefined);
+    queryReportMock.mockResolvedValue(datasetFixture);
+    getSettingsMock.mockResolvedValue({
+      startWithWindows: true,
+      minimizeToTray: true,
+      teamsEnabled: false,
+      teamsWebhookUrl: "",
+      lastRestoreSummary: null
+    });
+    getDatabaseSecurityStatusMock.mockResolvedValue({
+      databasePath: "C:\\BudgetIT\\budgetit.db",
+      keyPresent: true,
+      safeStorageAvailable: true
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it("passes axe checks for major routes", async () => {
+    const routes: Array<{ path: string; title: string }> = [
+      { path: "/dashboard", title: "Dashboard" },
+      { path: "/alerts", title: "Alerts" },
+      { path: "/reports", title: "Reports" },
+      { path: "/settings", title: "Settings" }
+    ];
+
+    for (const route of routes) {
+      const view = renderWorkspace(route.path);
+      await waitForTitle(route.title);
+      const result = await axe(view.container);
+      const severeViolations = result.violations.filter((entry) =>
+        entry.impact === "serious" || entry.impact === "critical"
+      );
+      expect(severeViolations).toHaveLength(0);
+      view.unmount();
+    }
+  }, 30000);
+
+  it("supports keyboard tab flow across shell controls", async () => {
+    renderWorkspace("/dashboard");
+    await waitForTitle("Dashboard");
+
+    const user = userEvent.setup();
+    const scenarioSelector = screen.getByLabelText("Scenario selector");
+    const globalSearch = screen.getByLabelText("Global search");
+    const commandPaletteButton = screen.getByRole("button", { name: "Command Palette" });
+
+    scenarioSelector.focus();
+    expect(document.activeElement).toBe(scenarioSelector);
+    await user.tab();
+    expect(document.activeElement).toBe(globalSearch);
+    await user.tab();
+    expect(document.activeElement).toBe(commandPaletteButton);
+
+    await user.keyboard("{Enter}");
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("completes a smoke navigation flow without uncaught renderer errors", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const user = userEvent.setup();
+    renderWorkspace("/dashboard");
+    await waitForTitle("Dashboard");
+
+    await user.click(screen.getByRole("link", { name: "Import" }));
+    await waitForTitle("Import");
+
+    await user.click(screen.getByRole("link", { name: "Alerts" }));
+    await waitForTitle("Alerts");
+
+    await user.click(screen.getByRole("link", { name: "Reports" }));
+    await waitForTitle("Reports");
+
+    await user.click(screen.getByRole("link", { name: "Settings" }));
+    await waitForTitle("Settings");
+
+    const errors = consoleErrorSpy.mock.calls
+      .flatMap((call) => call.map((entry) => String(entry)))
+      .join("\n");
+    expect(errors).not.toMatch(/uncaught|unhandled/i);
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/renderer/src/app/routes.tsx
+++ b/apps/renderer/src/app/routes.tsx
@@ -14,6 +14,7 @@ import { ServicesPage } from "../features/services/ServicesPage";
 import { SettingsPage } from "../features/settings/SettingsPage";
 import { TagsPage } from "../features/tags/TagsPage";
 import { VendorsPage } from "../features/vendors/VendorsPage";
+import { ErrorBoundary } from "../ui/primitives";
 
 export type AppRouteConfig = {
   key: string;
@@ -136,7 +137,18 @@ export function AppRoutes() {
     <Routes>
       <Route path="/" element={<Navigate replace to="/dashboard" />} />
       {APP_ROUTES.map((route) => (
-        <Route key={route.key} path={route.path} element={route.element} />
+        <Route
+          key={route.key}
+          path={route.path}
+          element={
+            <ErrorBoundary
+              label={`${route.label} failed to render`}
+              resetKey={route.path}
+            >
+              {route.element}
+            </ErrorBoundary>
+          }
+        />
       ))}
       <Route path="*" element={<Navigate replace to="/dashboard" />} />
     </Routes>

--- a/apps/renderer/src/features/alerts/AlertsPage.test.tsx
+++ b/apps/renderer/src/features/alerts/AlertsPage.test.tsx
@@ -130,7 +130,7 @@ describe("AlertsPage", () => {
         expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/)
       );
     });
-    expect(await screen.findByText(/snoozed until/i)).toBeInTheDocument();
+    expect(await screen.findByText("No alerts in this tab")).toBeInTheDocument();
   });
 
   it("focuses the correct alert after notification deep-link callback", async () => {

--- a/apps/renderer/src/main.tsx
+++ b/apps/renderer/src/main.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter } from "react-router-dom";
 import { AppShell } from "./app/AppShell";
 import { AppRoutes } from "./app/routes";
 import { ScenarioProvider } from "./features/scenarios/ScenarioContext";
+import { FeedbackProvider } from "./ui/feedback";
 import "./App.css";
 import { budgetItLightTheme } from "./ui/theme";
 
@@ -13,11 +14,13 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <ScenarioProvider>
       <FluentProvider theme={budgetItLightTheme}>
-        <BrowserRouter>
-          <AppShell>
-            <AppRoutes />
-          </AppShell>
-        </BrowserRouter>
+        <FeedbackProvider>
+          <BrowserRouter>
+            <AppShell>
+              <AppRoutes />
+            </AppShell>
+          </BrowserRouter>
+        </FeedbackProvider>
       </FluentProvider>
     </ScenarioProvider>
   </React.StrictMode>

--- a/apps/renderer/src/ui/feedback/FeedbackProvider.css
+++ b/apps/renderer/src/ui/feedback/FeedbackProvider.css
@@ -1,0 +1,44 @@
+.feedback-viewport {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 9999;
+  width: min(24rem, calc(100vw - 2rem));
+  display: grid;
+  gap: 0.5rem;
+  pointer-events: none;
+}
+
+.feedback-toast {
+  pointer-events: auto;
+  border: 1px solid #d0d7de;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.15);
+  padding: 0.65rem 0.75rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.feedback-toast--success {
+  border-left: 4px solid #16a34a;
+}
+
+.feedback-toast--error {
+  border-left: 4px solid #dc2626;
+}
+
+.feedback-toast--info {
+  border-left: 4px solid #0ea5e9;
+}
+
+.feedback-toast--warning {
+  border-left: 4px solid #f59e0b;
+}
+
+.feedback-toast__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+}

--- a/apps/renderer/src/ui/feedback/FeedbackProvider.tsx
+++ b/apps/renderer/src/ui/feedback/FeedbackProvider.tsx
@@ -1,0 +1,139 @@
+import {
+  Button,
+  Text,
+  Title3
+} from "@fluentui/react-components";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PropsWithChildren
+} from "react";
+
+import "./FeedbackProvider.css";
+
+export type FeedbackTone = "success" | "error" | "info" | "warning";
+
+type FeedbackItem = {
+  id: string;
+  tone: FeedbackTone;
+  message: string;
+  title?: string;
+};
+
+type NotifyOptions = {
+  tone: FeedbackTone;
+  message: string;
+  title?: string;
+  durationMs?: number;
+};
+
+type FeedbackContextValue = {
+  notify: (options: NotifyOptions) => void;
+  dismiss: (id: string) => void;
+};
+
+const noop = () => {
+  return;
+};
+
+const FeedbackContext = createContext<FeedbackContextValue>({
+  notify: noop,
+  dismiss: noop
+});
+
+function createFeedbackId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `feedback-${Date.now()}-${Math.floor(Math.random() * 100000)}`;
+}
+
+export function FeedbackProvider({ children }: PropsWithChildren) {
+  const [items, setItems] = useState<FeedbackItem[]>([]);
+  const timersRef = useRef(new Map<string, number>());
+
+  const dismiss = useCallback((id: string) => {
+    setItems((current) => current.filter((item) => item.id !== id));
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      window.clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+  }, []);
+
+  const notify = useCallback(
+    ({ tone, message, title, durationMs }: NotifyOptions) => {
+      const id = createFeedbackId();
+      const next: FeedbackItem = { id, tone, message, title };
+      setItems((current) => [next, ...current].slice(0, 6));
+
+      const timeoutMs = durationMs ?? (tone === "error" ? 7000 : 4500);
+      const timer = window.setTimeout(() => {
+        dismiss(id);
+      }, timeoutMs);
+      timersRef.current.set(id, timer);
+    },
+    [dismiss]
+  );
+
+  useEffect(() => {
+    return () => {
+      for (const timer of timersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      timersRef.current.clear();
+    };
+  }, []);
+
+  const value = useMemo<FeedbackContextValue>(
+    () => ({
+      notify,
+      dismiss
+    }),
+    [dismiss, notify]
+  );
+
+  return (
+    <FeedbackContext.Provider value={value}>
+      {children}
+      <section className="feedback-viewport" aria-label="Notifications" aria-live="polite">
+        {items.map((item) => (
+          <article
+            key={item.id}
+            className={`feedback-toast feedback-toast--${item.tone}`}
+            role={item.tone === "error" ? "alert" : "status"}
+          >
+            <div className="feedback-toast__header">
+              <Title3 style={{ margin: 0, fontSize: "0.95rem" }}>
+                {item.title ??
+                  (item.tone === "error"
+                    ? "Action failed"
+                    : item.tone === "success"
+                      ? "Action complete"
+                      : "Update")}
+              </Title3>
+              <Button
+                appearance="transparent"
+                aria-label="Dismiss notification"
+                onClick={() => dismiss(item.id)}
+                size="small"
+              >
+                Dismiss
+              </Button>
+            </div>
+            <Text>{item.message}</Text>
+          </article>
+        ))}
+      </section>
+    </FeedbackContext.Provider>
+  );
+}
+
+export function useFeedback(): FeedbackContextValue {
+  return useContext(FeedbackContext);
+}

--- a/apps/renderer/src/ui/feedback/index.ts
+++ b/apps/renderer/src/ui/feedback/index.ts
@@ -1,0 +1,5 @@
+export {
+  FeedbackProvider,
+  useFeedback,
+  type FeedbackTone
+} from "./FeedbackProvider";

--- a/apps/renderer/src/ui/primitives/ErrorBoundary.tsx
+++ b/apps/renderer/src/ui/primitives/ErrorBoundary.tsx
@@ -1,0 +1,73 @@
+import type { ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+import { Button, Card, Text } from "@fluentui/react-components";
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+  label?: string;
+  resetKey?: string | number;
+};
+
+type ErrorBoundaryState = {
+  error: Error | null;
+};
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = {
+    error: null
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    if (prevProps.resetKey !== this.props.resetKey && this.state.error) {
+      this.setState({ error: null });
+    }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    const label = this.props.label ?? "UI boundary";
+    console.error(`[${label}]`, error, info.componentStack);
+  }
+
+  private readonly handleRetry = (): void => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    return (
+      <Card
+        role="alert"
+        style={{
+          padding: "1rem",
+          display: "grid",
+          gap: "0.5rem"
+        }}
+      >
+        <Text weight="semibold">{this.props.label ?? "Something went wrong"}</Text>
+        <Text>{this.state.error.message}</Text>
+        <div style={{ display: "flex", gap: "0.5rem" }}>
+          <Button appearance="primary" onClick={this.handleRetry} size="small">
+            Retry
+          </Button>
+          <Button
+            appearance="secondary"
+            onClick={() => window.location.reload()}
+            size="small"
+          >
+            Reload app
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+}

--- a/apps/renderer/src/ui/primitives/InlineError.tsx
+++ b/apps/renderer/src/ui/primitives/InlineError.tsx
@@ -1,19 +1,29 @@
+import type { ReactNode } from "react";
 import { Card, Text } from "@fluentui/react-components";
 
 type InlineErrorProps = {
   message: string;
+  title?: string;
+  action?: ReactNode;
 };
 
-export function InlineError({ message }: InlineErrorProps) {
+export function InlineError({
+  message,
+  title = "Something went wrong",
+  action
+}: InlineErrorProps) {
   return (
     <Card
       style={{
         borderLeft: "4px solid #cf222e",
-        padding: "0.75rem 1rem"
+        padding: "0.75rem 1rem",
+        display: "grid",
+        gap: "0.5rem"
       }}
     >
-      <Text weight="semibold">Something went wrong</Text>
-      <Text style={{ display: "block", marginTop: "0.25rem" }}>{message}</Text>
+      <Text weight="semibold">{title}</Text>
+      <Text>{message}</Text>
+      {action ? <div>{action}</div> : null}
     </Card>
   );
 }

--- a/apps/renderer/src/ui/primitives/LoadingState.tsx
+++ b/apps/renderer/src/ui/primitives/LoadingState.tsx
@@ -1,0 +1,45 @@
+import { Card, Text } from "@fluentui/react-components";
+
+type LoadingStateProps = {
+  label?: string;
+  rows?: number;
+};
+
+export function LoadingState({
+  label = "Loading...",
+  rows = 4
+}: LoadingStateProps) {
+  return (
+    <Card
+      aria-live="polite"
+      style={{
+        padding: "1rem",
+        display: "grid",
+        gap: "0.5rem"
+      }}
+    >
+      <Text weight="semibold">{label}</Text>
+      <div
+        style={{
+          display: "grid",
+          gap: "0.4rem"
+        }}
+      >
+        {Array.from({ length: Math.max(rows, 1) }).map((_, index) => (
+          <div
+            key={index}
+            aria-hidden
+            style={{
+              height: "0.7rem",
+              borderRadius: "999px",
+              width: index % 3 === 0 ? "82%" : index % 2 === 0 ? "65%" : "100%",
+              background: "linear-gradient(90deg, #e5e7eb 0%, #f3f4f6 45%, #e5e7eb 100%)",
+              backgroundSize: "220% 100%",
+              animation: "budgetit-loading-wave 1.3s ease-in-out infinite"
+            }}
+          />
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/apps/renderer/src/ui/primitives/PanelState.tsx
+++ b/apps/renderer/src/ui/primitives/PanelState.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+import { Button } from "@fluentui/react-components";
+
+import { EmptyState } from "./EmptyState";
+import { InlineError } from "./InlineError";
+import { LoadingState } from "./LoadingState";
+
+type PanelStateProps = {
+  loading: boolean;
+  error: string | null;
+  isEmpty: boolean;
+  loadingLabel: string;
+  emptyTitle: string;
+  emptyDescription: string;
+  onRetry?: () => void;
+  children: ReactNode;
+};
+
+export function PanelState({
+  loading,
+  error,
+  isEmpty,
+  loadingLabel,
+  emptyTitle,
+  emptyDescription,
+  onRetry,
+  children
+}: PanelStateProps) {
+  if (loading) {
+    return <LoadingState label={loadingLabel} />;
+  }
+
+  if (error) {
+    return (
+      <InlineError
+        message={error}
+        action={
+          onRetry ? (
+            <Button appearance="secondary" onClick={onRetry} size="small">
+              Retry
+            </Button>
+          ) : undefined
+        }
+      />
+    );
+  }
+
+  if (isEmpty) {
+    return <EmptyState title={emptyTitle} description={emptyDescription} />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/renderer/src/ui/primitives/index.ts
+++ b/apps/renderer/src/ui/primitives/index.ts
@@ -1,7 +1,10 @@
 export { ConfirmDialog } from "./ConfirmDialog";
+export { ErrorBoundary } from "./ErrorBoundary";
 export { EmptyState } from "./EmptyState";
 export { EntityTable } from "./EntityTable";
 export { FormDrawer } from "./FormDrawer";
 export { InlineError } from "./InlineError";
+export { LoadingState } from "./LoadingState";
 export { PageHeader } from "./PageHeader";
+export { PanelState } from "./PanelState";
 export { StatusChip } from "./StatusChip";

--- a/apps/renderer/src/ui/primitives/panel-state.test.tsx
+++ b/apps/renderer/src/ui/primitives/panel-state.test.tsx
@@ -1,0 +1,113 @@
+/* @vitest-environment jsdom */
+
+import "@testing-library/jest-dom/vitest";
+import { Button } from "@fluentui/react-components";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ErrorBoundary } from "./ErrorBoundary";
+import { PanelState } from "./PanelState";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("panel state primitives", () => {
+  it("renders loading contract with skeleton rows", () => {
+    render(
+      <PanelState
+        loading
+        error={null}
+        isEmpty={false}
+        loadingLabel="Loading contracts..."
+        emptyTitle="Empty"
+        emptyDescription="None"
+      >
+        <div>content</div>
+      </PanelState>
+    );
+
+    expect(screen.getByText("Loading contracts...")).toBeInTheDocument();
+  });
+
+  it("renders empty-state and error fallback contracts", () => {
+    const onRetry = vi.fn();
+    const { rerender } = render(
+      <PanelState
+        loading={false}
+        error={null}
+        isEmpty
+        loadingLabel="Loading"
+        emptyTitle="No data"
+        emptyDescription="Try another filter."
+      >
+        <div>content</div>
+      </PanelState>
+    );
+    expect(screen.getByText("No data")).toBeInTheDocument();
+
+    rerender(
+      <PanelState
+        loading={false}
+        error="Exploded panel"
+        isEmpty={false}
+        loadingLabel="Loading"
+        emptyTitle="No data"
+        emptyDescription="Try another filter."
+        onRetry={onRetry}
+      >
+        <div>content</div>
+      </PanelState>
+    );
+    expect(screen.getByText("Exploded panel")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders error boundary fallback and recovers on reset key change", () => {
+    function BrokenWidget({ crash }: { crash: boolean }) {
+      if (crash) {
+        throw new Error("Widget crashed");
+      }
+      return <div>Widget healthy</div>;
+    }
+
+    const { rerender } = render(
+      <ErrorBoundary label="Widget boundary" resetKey="a">
+        <BrokenWidget crash />
+      </ErrorBoundary>
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Widget boundary");
+    expect(screen.getByText("Widget crashed")).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary label="Widget boundary" resetKey="b">
+        <BrokenWidget crash={false} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("Widget healthy")).toBeInTheDocument();
+  });
+
+  it("keeps custom inline-error action reachable via keyboard", () => {
+    const actionSpy = vi.fn();
+    render(
+      <PanelState
+        loading={false}
+        error="Cannot load table"
+        isEmpty={false}
+        loadingLabel="Loading"
+        emptyTitle="No data"
+        emptyDescription="Try another filter."
+        onRetry={actionSpy}
+      >
+        <Button>unreachable</Button>
+      </PanelState>
+    );
+
+    const retry = screen.getByRole("button", { name: "Retry" });
+    retry.focus();
+    fireEvent.keyDown(retry, { key: "Enter" });
+    fireEvent.click(retry);
+    expect(actionSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,10 +44,12 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "jsdom": "^28.1.0",
-        "vite": "^6.2.1"
+        "vite": "^6.2.1",
+        "vitest-axe": "^0.1.0"
       }
     },
     "apps/renderer/node_modules/vite": {
@@ -3718,6 +3720,19 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -4611,6 +4626,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {
@@ -5643,8 +5667,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -7619,6 +7642,12 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "dev": true
     },
     "node_modules/lodash.defaults": {
@@ -10544,6 +10573,35 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
+      }
+    },
+    "node_modules/vitest-axe/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/w3c-xmlserializer": {


### PR DESCRIPTION
## Summary\n- add shared UX primitives for loading state skeletons, panel state handling, and reusable error boundaries\n- introduce global feedback toast provider and wire it into app bootstrap + command/actions pages\n- harden primary pages (dashboard, alerts, import, reports, settings) with consistent async/error/empty behavior and retry actions\n- add route-level error boundaries and widget-level boundaries on dashboard/reports\n- add test coverage for panel state contracts, action-failure recovery, accessibility axe checks, keyboard tab flow, and smoke navigation\n\n## Testing\n- npm run lint --workspace @budgetit/renderer\n- npm run typecheck --workspace @budgetit/renderer\n- npm run test --workspace @budgetit/renderer\n- npm run build --workspace @budgetit/renderer\n- npm run test\n\nCloses #71